### PR TITLE
Add build check, advisory lint, and CodeQL to PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,45 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade pip build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Validate package metadata
+        run: twine check dist/*
+
+  lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true  # advisory only — pre-existing findings not yet cleaned up
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install lint tools
+        run: python -m pip install --upgrade pip ruff mypy
+
+      - name: Install package (for mypy import resolution)
+        run: pip install -e .
+
+      - name: Ruff
+        run: ruff check src/ tests/
+
+      - name: Mypy
+        run: mypy src/fastdocparse --ignore-missing-imports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    continue-on-error: true  # advisory only — pre-existing findings not yet cleaned up
     steps:
       - uses: actions/checkout@v4
 
@@ -63,8 +62,15 @@ jobs:
       - name: Install package (for mypy import resolution)
         run: pip install -e .
 
+      # Advisory only, at the step level — pre-existing findings not yet cleaned up.
+      # Job-level continue-on-error doesn't block merge either, but still shows the
+      # job as a red "failed" check, which misrepresents "advisory" as "broken."
+      # Step-level continue-on-error lets the job itself report success/green while
+      # still running and logging the findings for anyone who wants to see them.
       - name: Ruff
+        continue-on-error: true
         run: ruff check src/ tests/
 
       - name: Mypy
+        continue-on-error: true
         run: mypy src/fastdocparse --ignore-missing-imports

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 1 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['python']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ venv/
 dist/
 build/
 .env
+.mypy_cache/
+.ruff_cache/


### PR DESCRIPTION
## Summary
- New blocking `build` job: `python -m build` + `twine check` on every PR
- New advisory `lint` job: ruff + mypy (continue-on-error — 173 pre-existing ruff findings need a cleanup pass before this can block)
- New `codeql.yml` workflow: GitHub's free security static analysis

## Test plan
- [x] Verified `python -m build` + `twine check` pass locally before pushing
- [ ] Confirm all checks actually run on this PR and report their real names
- [ ] After merge: add `build` and CodeQL's real context name to required branch-protection checks