### PR TITLE
Make lint report its true status (red on findings, still non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,15 @@ jobs:
       - name: Install package (for mypy import resolution)
         run: pip install -e .
 
-      # Advisory only, at the step level — pre-existing findings not yet cleaned up.
-      # Job-level continue-on-error doesn't block merge either, but still shows the
-      # job as a red "failed" check, which misrepresents "advisory" as "broken."
-      # Step-level continue-on-error lets the job itself report success/green while
-      # still running and logging the findings for anyone who wants to see them.
+      # Advisory means "doesn't block merge" (this job isn't in required_status_checks),
+      # not "hide failures." No continue-on-error: if either tool finds something, the
+      # job genuinely reports red, so there's an honest signal to look at — it just
+      # can't stop a merge on its own. `if: always()` on Mypy means a Ruff failure
+      # doesn't skip it — both tools always run to completion, so one findings report
+      # shows everything instead of stopping at the first tool that complains.
       - name: Ruff
-        continue-on-error: true
         run: ruff check src/ tests/
 
       - name: Mypy
-        continue-on-error: true
+        if: always()
         run: mypy src/fastdocparse --ignore-missing-imports


### PR DESCRIPTION
## Summary
- Removes continue-on-error from the Ruff/Mypy steps — lint now genuinely fails (red) when there are findings, instead of always showing green
- Adds `if: always()` on Mypy so a Ruff failure doesn't skip it — both run every time
- lint stays out of required_status_checks, so this still can't block a merge on its own — "advisory" now means "non-blocking," not "hidden"

## Test plan
- [ ] Confirm lint shows red on this PR (173 pre-existing ruff findings expected)
- [ ] Confirm the PR is still mergeable despite lint being red