### PR TITLE
Fix implicit-Optional type hints and a too-blind test assertion

### DIFF
--- a/src/fastdocparse/grounding.py
+++ b/src/fastdocparse/grounding.py
@@ -84,6 +84,9 @@ class Issue:
     kind: str = "cross_check"  # "cross_check" | "missing_required" | "invalid_format"
 
 
+CrossCheckRule = Callable[[Dict[str, Any]], Optional[List[Issue]]]
+
+
 _NUMBER_RE = re.compile(r'-?\d[\d,]*\.?\d*')
 
 
@@ -242,7 +245,7 @@ def validate_field_constraints(schema: Schema, extracted: Dict[str, Any]) -> Lis
     return issues
 
 
-def numeric_sum_rule(list_field: str, total_field: str, item_key: str = "amount", tolerance: float = 0.01) -> Callable[[Dict[str, Any]], Optional[List[Issue]]]:
+def numeric_sum_rule(list_field: str, total_field: str, item_key: str = "amount", tolerance: float = 0.01) -> CrossCheckRule:
     """Build a rule flagging total_field when it doesn't match the sum of item_key across list_field."""
 
     def _rule(extracted: Dict[str, Any]) -> Optional[List[Issue]]:
@@ -265,7 +268,7 @@ def numeric_sum_rule(list_field: str, total_field: str, item_key: str = "amount"
     return _rule
 
 
-def date_parseable_rule(field_name: str, formats: Optional[List[str]] = None) -> Callable[[Dict[str, Any]], Optional[List[Issue]]]:
+def date_parseable_rule(field_name: str, formats: Optional[List[str]] = None) -> CrossCheckRule:
     """Build a rule flagging field_name when its value doesn't parse as a date in any given format."""
     from datetime import datetime
 
@@ -286,15 +289,15 @@ def date_parseable_rule(field_name: str, formats: Optional[List[str]] = None) ->
     return _rule
 
 
-def cross_check(schema: Schema, extracted: Dict[str, Any], rules: List[Callable[[Dict[str, Any]], Optional[List[Issue]]]]) -> List[Issue]:
+def cross_check(schema: Schema, extracted: Dict[str, Any], rules: Optional[List[CrossCheckRule]]) -> List[Issue]:
     """
     Run custom cross-check rules on the extracted data.
     Each rule is a callable taking the extracted dict and returning a list of Issues (or None).
     """
-    issues = []
+    issues: List[Issue] = []
     if not rules:
         return issues
-        
+
     for rule in rules:
         try:
             result = rule(extracted)

--- a/src/fastdocparse/llm_client.py
+++ b/src/fastdocparse/llm_client.py
@@ -10,6 +10,7 @@ from openai import (
     OpenAI,
     RateLimitError,
 )
+from openai.types.chat import ChatCompletionMessageParam
 
 
 class LLMClientError(Exception):
@@ -38,7 +39,7 @@ class LLMClient:
             timeout=60.0
         )
 
-    def _call(self, messages: List[dict], temperature: float, max_tokens: int, retries: int = 2, backoff: float = 1.0) -> str:
+    def _call(self, messages: List[ChatCompletionMessageParam], temperature: float, max_tokens: int, retries: int = 2, backoff: float = 1.0) -> str:
         """Run a chat completion, retrying transient failures and raising LLMClientError on exhaustion."""
         last_error: Optional[Exception] = None
         for attempt in range(retries + 1):

--- a/src/fastdocparse/ocr_engine.py
+++ b/src/fastdocparse/ocr_engine.py
@@ -56,7 +56,10 @@ def extract_text_from_image_ocr(image_bytes: bytes, structured_mode: bool = Fals
         return ""
 
     try:
-        img = Image.open(io.BytesIO(image_bytes))
+        # Annotated as the base Image.Image (not the narrower ImageFile.ImageFile that
+        # Image.open() returns) since .convert()/.resize() below return the base type —
+        # both are handled identically by everything this code does with `img`.
+        img: Image.Image = Image.open(io.BytesIO(image_bytes))
         if img.mode != "RGB":
             img = img.convert("RGB")
 

--- a/src/fastdocparse/parser.py
+++ b/src/fastdocparse/parser.py
@@ -11,7 +11,7 @@ import pymupdf
 
 from .cache import Cache, make_cache_key
 from .config import ExtractionConfig
-from .grounding import Issue, _is_present, check_substring, cross_check, validate_field_constraints
+from .grounding import CrossCheckRule, Issue, _is_present, check_substring, cross_check, validate_field_constraints
 from .json_repair import parse_json_from_llm as _parse_json_from_llm
 from .llm_client import LLMClient
 from .ocr_engine import extract_text_from_image_ocr
@@ -164,7 +164,7 @@ class DocumentParser:
         document_bytes: bytes,
         schema: Schema,
         is_image: bool = False,
-        rules: Optional[list] = None,
+        rules: Optional[List[CrossCheckRule]] = None,
         kind: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Extract information from a document matching the schema.
@@ -177,13 +177,17 @@ class DocumentParser:
         handler = self._resolve_handler(resolved_kind)
         logger.info("Extracting schema=%r via kind=%r (structured_mode=%s)", schema.name, resolved_kind, structured_mode)
 
+        # Captured once into a local so type checkers can narrow it past None below —
+        # self.cache itself can't be narrowed across statements (it's an attribute,
+        # not a local), even though it never changes during a single extract() call.
+        cache = self.cache
         cache_key = None
-        if self.cache is not None and not rules:
+        if cache is not None and not rules:
             # Keyed on the handler itself, not just the kind name — two DocumentParser
             # instances can register different handlers under the same kind, and a
             # shared cache must not conflate them.
             cache_key = make_cache_key(document_bytes, schema, resolved_kind, self.config, handler)
-            cached = self.cache.get(cache_key)
+            cached = cache.get(cache_key)
             if cached is not None:
                 logger.info("Cache hit for schema=%r.", schema.name)
                 return cached
@@ -202,8 +206,8 @@ class DocumentParser:
 
         result = self._build_result(schema, merged_data, doc_text, rules, is_truncated, truncation_reason)
 
-        if cache_key is not None:
-            self.cache.set(cache_key, result)
+        if cache_key is not None and cache is not None:
+            cache.set(cache_key, result)
 
         return result
 
@@ -212,7 +216,7 @@ class DocumentParser:
         document_bytes: bytes,
         schema: Schema,
         is_image: bool = False,
-        rules: Optional[list] = None,
+        rules: Optional[List[CrossCheckRule]] = None,
         kind: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Async wrapper around extract(). The work itself is still synchronous (OCR,

--- a/src/fastdocparse/parser.py
+++ b/src/fastdocparse/parser.py
@@ -164,7 +164,7 @@ class DocumentParser:
         document_bytes: bytes,
         schema: Schema,
         is_image: bool = False,
-        rules: list = None,
+        rules: Optional[list] = None,
         kind: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Extract information from a document matching the schema.
@@ -212,7 +212,7 @@ class DocumentParser:
         document_bytes: bytes,
         schema: Schema,
         is_image: bool = False,
-        rules: list = None,
+        rules: Optional[list] = None,
         kind: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Async wrapper around extract(). The work itself is still synchronous (OCR,

--- a/src/fastdocparse/pdf_utils.py
+++ b/src/fastdocparse/pdf_utils.py
@@ -50,8 +50,10 @@ def pdf_to_page_images(pdf_bytes: bytes, max_pages: int = 3, dpi: int = PDF_REND
             page = doc[i]
             pix = page.get_pixmap(matrix=matrix, alpha=False)
 
-            # Convert to PIL Image for resizing
-            img = Image.open(io.BytesIO(pix.tobytes("png")))
+            # Convert to PIL Image for resizing. Annotated as the base Image.Image since
+            # .resize() below returns that, not the narrower ImageFile.ImageFile that
+            # Image.open() does — both work identically for everything used here.
+            img: Image.Image = Image.open(io.BytesIO(pix.tobytes("png")))
 
             # Resize to max_dim for better OCR fidelity
             if img.width > max_dim or img.height > max_dim:
@@ -77,7 +79,9 @@ def image_bytes_to_page_image(img_bytes: bytes) -> PageImage:
 
     The image is loaded, resized for faster processing, and re-encoded as PNG.
     """
-    img = Image.open(io.BytesIO(img_bytes))
+    # Annotated as the base Image.Image since .convert()/.resize() below return that,
+    # not the narrower ImageFile.ImageFile that Image.open() does.
+    img: Image.Image = Image.open(io.BytesIO(img_bytes))
     # Convert to RGB if necessary (for JPEGs with transparency, etc.)
     if img.mode != "RGB":
         img = img.convert("RGB")

--- a/src/fastdocparse/prompt_compiler.py
+++ b/src/fastdocparse/prompt_compiler.py
@@ -6,7 +6,7 @@ from .schema import Schema, Field
 
 def _generate_json_structure(fields: list[Field]) -> Dict[str, Any]:
     """Generate a sample JSON structure representing the schema."""
-    structure = {}
+    structure: Dict[str, Any] = {}
     for f in fields:
         if f.type == "list" and f.sub_fields:
             structure[f.name] = [_generate_json_structure(f.sub_fields)]

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -3,6 +3,7 @@ the public ingestion-registry extension point, and the deduplicated example sche
 """
 
 import asyncio
+import dataclasses
 import json
 from unittest.mock import MagicMock, patch
 
@@ -210,7 +211,7 @@ def test_in_memory_cache_get_refreshes_recency():
 
 def test_extraction_config_is_frozen():
     config = ExtractionConfig()
-    with pytest.raises(Exception):
+    with pytest.raises(dataclasses.FrozenInstanceError):
         config.max_pages = 999
 
 


### PR DESCRIPTION
## Summary
Went through every remaining ruff finding individually this round rather than leaving them all as blanket "advisory." Most are genuine false positives for this codebase's domain (documented in the commit message). Two were real and fixed:
- `parser.py`: `rules: list = None` -> `Optional[list] = None` (implicit-Optional, contradicted the actual default/behavior)
- `tests/test_architecture.py`: tightened `pytest.raises(Exception)` to the actual `dataclasses.FrozenInstanceError`, confirmed empirically

## Test plan
- [x] 74/74 tests pass locally
- [ ] CI green