### PR TITLE
Add README badges and PyPI classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # fastdocparse
 
+[![PyPI](https://img.shields.io/pypi/v/fastdocparse.svg)](https://pypi.org/project/fastdocparse/)
+[![CI](https://github.com/pranjalparmar/fastdocparse/actions/workflows/ci.yml/badge.svg)](https://github.com/pranjalparmar/fastdocparse/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Extract structured data from semi-structured documents — invoices, bills, tax forms, resumes, bank statements, shipment manifests — using any OpenAI-compatible LLM (OpenAI, Ollama, vLLM, Groq, etc.), with **per-field grounding and confidence**, not just raw extraction.
 
 ## Why this, not just another parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,17 @@ description = "Extract structured data from semi-structured documents using any 
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9,<3.13"  # capped by rapidocr-onnxruntime's own upper bound (checked live against PyPI)
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Developers",
+    "Topic :: Text Processing :: Linguistic",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "pydantic>=2.0",
     "openai>=1.0",


### PR DESCRIPTION
## Summary
- PyPI version, CI status, MIT license badges in README — each verified to actually render (fetched content, not just HTTP status)
- Dropped the Python-versions badge: it genuinely showed "python: missing" since pyproject.toml had no classifiers
- Added classifiers so that badge works automatically on the next release, without forcing one now

## Test plan
- [x] Build + twine check pass locally
- [x] 74/74 tests pass
- [ ] CI green