### PR TITLE
Add PyPI keywords and project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,17 @@ description = "Extract structured data from semi-structured documents using any 
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9,<3.13"  # capped by rapidocr-onnxruntime's own upper bound (checked live against PyPI)
+keywords = [
+    "document-extraction",
+    "llm",
+    "pdf",
+    "ocr",
+    "invoice-extraction",
+    "structured-data",
+    "openai",
+    "ollama",
+    "grounding",
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -28,6 +39,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/pranjalparmar/fastdocparse"
+Repository = "https://github.com/pranjalparmar/fastdocparse"
+Issues = "https://github.com/pranjalparmar/fastdocparse/issues"
+Documentation = "https://github.com/pranjalparmar/fastdocparse/tree/main/docs"
 
 [project.scripts]
 fastdocparse = "fastdocparse.cli:app"


### PR DESCRIPTION
## Summary
- pyproject.toml had no keywords (hurts PyPI search discoverability) and no [project.urls] (PyPI sidebar had zero links)
- Added both; verified in the actual built wheel metadata
- Also set GitHub repo topics via API (python, llm, document-processing, pdf, ocr, etc.) -- not a file change

## Test plan
- [x] Build + twine check pass
- [x] 74/74 tests pass
- [ ] CI green