### PR TITLE
Add community health files and surface the comparison table in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: ''
+labels: bug
+assignees: ''
+---
+
+**What happened**
+
+A clear description of the bug.
+
+**What you expected**
+
+What you expected to happen instead.
+
+**To reproduce**
+
+- Schema used (paste it, or a minimal version that still reproduces the bug)
+- Document type (e.g. "digital PDF invoice", "scanned PNG receipt") — please don't attach the document itself if it's sensitive
+- Command or code you ran
+- Exact error message / output
+
+**Environment**
+
+- fastdocparse version (`pip show fastdocparse`):
+- Python version:
+- OS:
+- Model/backend used (e.g. `gpt-4o-mini`, `llama3.2` via Ollama):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**What problem does this solve?**
+
+A clear description of what you're trying to do that isn't currently possible
+(or is currently awkward).
+
+**Proposed solution**
+
+What you'd like to happen. If you have an idea of the API shape (a new
+`Schema`/`Field` option, a new CLI flag, etc.), sketch it out.
+
+**Alternatives considered**
+
+Any alternative solutions or workarounds you've thought about.
+
+**Additional context**
+
+Anything else relevant — links to similar features in other tools, example
+documents/schemas, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What this does
+
+<!-- Brief description. Link the issue this closes, if any: "Fixes #123" -->
+
+## Checklist
+
+- [ ] Added or updated tests for anything behavioral this changes
+- [ ] Ran the full suite locally (`pytest -v`), not just the file touched
+- [ ] Updated `docs/` and/or `README.md` if a CLI flag, `Schema`/`Field` option,
+      or output shape changed
+- [ ] Kept the PR scoped to one thing (see `CONTRIBUTING.md` if unsure)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,61 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and unwelcome sexual attention
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior they deem inappropriate, threatening, offensive, or
+harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull
+requests, discussions) and also applies when an individual is officially
+representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer at the contact listed on the
+[GitHub profile](https://github.com/pranjalparmar). All complaints will be
+reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ No extra LLM call for any of this — it's deterministic, string/rule-based vali
 
 **Where it fits:** semi-structured documents with recurring fields (invoices, bills, tax forms, resumes, statements), and prose documents where *proving* a value came from the source matters (contracts, legal clauses, insurance claims). It is not a vision-LLM pipeline — it works from extracted text (digital PDF text layer, or local OCR for scans/images), which is what keeps it fast, cheap, and usable with small local models. Messy handwritten forms or complex multi-column layouts are a known weaker spot (see [document-extractor-spec.md](document-extractor-spec.md)).
 
+## How this compares
+
+| Project | Approach | Where it beats fastdocparse | Where fastdocparse can beat it |
+|---|---|---|---|
+| **[Sparrow](https://github.com/katanaml/sparrow)** (katanaml) | Vision-LLM first (MLX/vLLM/Ollama/Mistral OCR), multi-service platform, API-first | Layout-aware (sees the page), mature, table templates for complex tables | No GPU required, single `pip install`, Pydantic-schema devex vs. raw JSON-string CLI args |
+| **[LangExtract](https://github.com/google/langextract)** (Google) | Text-first, source-grounding (character-offset mapping), few-shot examples required | Real grounding/traceability, brand trust | Purpose-built for documents (OCR routing) vs. text-in/text-out |
+
+**The honest edge:** *fast, cheap, local-model-friendly extraction for clean-to-moderate documents* — not "better than Sparrow at everything." This has not yet been validated with a real head-to-head benchmark ([tracking issue](https://github.com/pranjalparmar/fastdocparse/issues/19)) — treat it as a design goal, not a proven claim, until that lands.
+
 ## Two ways to use it
 
 | | Who it's for | How |


### PR DESCRIPTION
## Summary
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`
- Add `.github/pull_request_template.md`
- Move the Sparrow/LangExtract comparison table from `document-extractor-spec.md` into the README, right after the "why this, not just another parser" section — that's the first objection a skeptical reader has, worth answering early
- Enabled GitHub Discussions on the repo (not a file change, done via API)

## Test plan
- Docs-only change, no code touched — CI (`test`, `build`) should pass unaffected
- Verified `README.md` renders correctly (table syntax, links)