### PR TITLE
test: add explicit check=True to subprocess.run (PLW1510)

### DIFF
--- a/tests/test_severe_edge_cases.py
+++ b/tests/test_severe_edge_cases.py
@@ -41,8 +41,7 @@ def test_catastrophic_backtracking_pattern_does_not_hang():
         "print(f'ELAPSED={time.time() - start}')\n"
     )
     # Generous outer bound — this only needs to catch a genuine hang, not time the guard.
-    result = subprocess.run([sys.executable, "-c", code], timeout=30, capture_output=True, text=True)
-    assert result.returncode == 0, result.stderr
+    result = subprocess.run([sys.executable, "-c", code], timeout=30, capture_output=True, text=True, check=True)
 
     elapsed_line = next(line for line in result.stdout.splitlines() if line.startswith("ELAPSED="))
     elapsed = float(elapsed_line.split("=")[1])


### PR DESCRIPTION
Closes #11

## What
Add explicit check=True to the single subprocess.run call in tests/test_severe_edge_cases.py, resolving the PLW1510 lint (subprocess without an explicit check argument).

## Why
The test already asserted eturncode == 0, so the subprocess was always expected to succeed. check=True makes that expectation explicit and removes the now-redundant manual assertion (failures still surface stderr via CalledProcessError).

## Verification
- uff check tests/test_severe_edge_cases.py --select PLW1510 -> All checks passed
- python -m py_compile tests/test_severe_edge_cases.py -> OK