### PR TITLE
style: sort imports across src/ and tests/ (ruff I001)

### DIFF
--- a/src/fastdocparse/__init__.py
+++ b/src/fastdocparse/__init__.py
@@ -10,9 +10,21 @@ OpenAI-compatible LLM, with per-field grounding and confidence.
 
 from .cache import Cache, InMemoryCache
 from .config import ExtractionConfig
-from .grounding import Issue, check_substring, cross_check, date_parseable_rule, numeric_sum_rule, validate_field_constraints
+from .grounding import (
+    Issue,
+    check_substring,
+    cross_check,
+    date_parseable_rule,
+    numeric_sum_rule,
+    validate_field_constraints,
+)
 from .llm_client import LLMClient, LLMClientError
-from .parser import DocumentParser, EmptyDocumentError, UnknownIngestionKindError, register_default_ingestion_handler
+from .parser import (
+    DocumentParser,
+    EmptyDocumentError,
+    UnknownIngestionKindError,
+    register_default_ingestion_handler,
+)
 from .result import ExtractionMeta, ExtractionResult, FieldResult
 from .schema import Field, Schema
 from .schema_compiler import compile_schema_from_description

--- a/src/fastdocparse/grounding.py
+++ b/src/fastdocparse/grounding.py
@@ -4,9 +4,10 @@ import logging
 import re
 import signal
 import threading
-from datetime import datetime
-from typing import Any, Dict, List, Callable, Optional
 from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
 from .schema import Schema
 
 logger = logging.getLogger(__name__)

--- a/src/fastdocparse/ocr_engine.py
+++ b/src/fastdocparse/ocr_engine.py
@@ -7,6 +7,7 @@ import io
 import logging
 import threading
 from typing import List, Tuple
+
 from PIL import Image
 
 logger = logging.getLogger(__name__)

--- a/src/fastdocparse/parser.py
+++ b/src/fastdocparse/parser.py
@@ -11,7 +11,14 @@ import pymupdf
 
 from .cache import Cache, make_cache_key
 from .config import ExtractionConfig
-from .grounding import CrossCheckRule, Issue, _is_present, check_substring, cross_check, validate_field_constraints
+from .grounding import (
+    CrossCheckRule,
+    Issue,
+    _is_present,
+    check_substring,
+    cross_check,
+    validate_field_constraints,
+)
 from .json_repair import parse_json_from_llm as _parse_json_from_llm
 from .llm_client import LLMClient
 from .ocr_engine import extract_text_from_image_ocr

--- a/src/fastdocparse/prompt_compiler.py
+++ b/src/fastdocparse/prompt_compiler.py
@@ -2,7 +2,9 @@
 
 import json
 from typing import Any, Dict
-from .schema import Schema, Field
+
+from .schema import Field, Schema
+
 
 def _generate_json_structure(fields: list[Field]) -> Dict[str, Any]:
     """Generate a sample JSON structure representing the schema."""

--- a/src/fastdocparse/schema.py
+++ b/src/fastdocparse/schema.py
@@ -2,7 +2,8 @@
 
 import json
 from pathlib import Path
-from typing import List, Optional, Tuple, Dict, Any, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 from pydantic import BaseModel, field_validator
 
 

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -12,7 +12,11 @@ import pytest
 from fastdocparse.cache import InMemoryCache, make_cache_key
 from fastdocparse.config import ExtractionConfig
 from fastdocparse.example_schemas import INVOICE_SCHEMA
-from fastdocparse.parser import INGESTION_HANDLERS, DocumentParser, register_default_ingestion_handler
+from fastdocparse.parser import (
+    INGESTION_HANDLERS,
+    DocumentParser,
+    register_default_ingestion_handler,
+)
 from fastdocparse.schema import Field, Schema
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,13 +1,14 @@
 """Tests for the generalized document extractor Phase 1 & 2."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
-from fastdocparse.schema import Schema, Field
+import pytest
+
 from fastdocparse.example_schemas import INVOICE_SCHEMA
+from fastdocparse.grounding import Issue
 from fastdocparse.llm_client import LLMClient
 from fastdocparse.parser import DocumentParser, _parse_json_from_llm
-from fastdocparse.grounding import Issue
+from fastdocparse.schema import Field, Schema
 
 
 def test_tc1_1_invoice_schema_extraction():
@@ -275,7 +276,7 @@ def test_tc4_2_structured_mode_disabled():
 
 def test_tc4_3_ocr_structured_formatting():
     """TC4.3 - Verify OCR engine formats output with X coordinates in structured_mode."""
-    from fastdocparse.ocr_engine import extract_text_from_image_ocr, HAS_RAPID_OCR
+    from fastdocparse.ocr_engine import HAS_RAPID_OCR, extract_text_from_image_ocr
     if not HAS_RAPID_OCR:
         pytest.skip("RapidOCR not installed")
         

--- a/tests/test_schema_compiler.py
+++ b/tests/test_schema_compiler.py
@@ -1,7 +1,8 @@
 """Tests for compiling a plain-English description into a Schema."""
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from fastdocparse.llm_client import LLMClient
 from fastdocparse.schema_compiler import compile_schema_from_description

--- a/tests/test_severe_edge_cases.py
+++ b/tests/test_severe_edge_cases.py
@@ -14,7 +14,7 @@ from fastdocparse.grounding import validate_field_constraints
 from fastdocparse.json_repair import parse_json_from_llm
 from fastdocparse.parser import DocumentParser, EmptyDocumentError
 from fastdocparse.pdf_utils import chunk_document_text
-from fastdocparse.schema import Schema, Field
+from fastdocparse.schema import Field, Schema
 
 
 def test_catastrophic_backtracking_pattern_does_not_hang():


### PR DESCRIPTION
Closes #10

## What
Sort imports across src/ and 	ests/ to satisfy uff I001 (applied via uff check --select I001 --fix). Purely import reordering/line-wrapping — no logic changes.

## Verification
- uff check --select I001 src tests -> All checks passed
- python -m py_compile on all changed files -> OK