### PR TITLE
refactor: simplify boolean returns in grounding

### DIFF
--- a/src/fastdocparse/grounding.py
+++ b/src/fastdocparse/grounding.py
@@ -20,9 +20,7 @@ def _is_present(value: Any) -> bool:
     "grounded" either, since an empty string is a substring of anything)."""
     if value is None:
         return False
-    if isinstance(value, str) and not value.strip():
-        return False
-    return True
+    return not (isinstance(value, str) and not value.strip())
 
 
 class _PatternTimeout(Exception):
@@ -199,10 +197,7 @@ def check_substring(value: Any, source_text: str, numeric: bool = False, date: b
     val_clean = re.sub(r'\W+', '', val_str)
     source_clean = re.sub(r'\W+', '', source_lower)
     
-    if val_clean and val_clean in source_clean:
-        return True
-        
-    return False
+    return bool(val_clean and val_clean in source_clean)
 
 
 def validate_field_constraints(schema: Schema, extracted: Dict[str, Any]) -> List[Issue]:


### PR DESCRIPTION
## Summary

Simplifies two boolean return patterns in `src/fastdocparse/grounding.py`.

### Changes

- Simplified `_is_present()` to return the boolean expression directly.
- Simplified the substring check to return a boolean expression directly.

These changes address #17 and preserve the existing behavior.

## Validation

- `ruff check --select SIM103 src/` ✅
- `git diff --check` ✅
- `pytest -v` ⚠️ Test collection could not complete in the local Python 3.13 environment because the project's `rapidocr-onnxruntime>=1.3` dependency is unavailable for this environment.

No dependency or project configuration files were changed.