### PR TITLE
fix: raise TypeError for invalid example types

### DIFF
--- a/src/fastdocparse/schema.py
+++ b/src/fastdocparse/schema.py
@@ -55,7 +55,7 @@ class Schema(BaseModel):
                 if not isinstance(ex, tuple) or len(ex) != 2:
                     raise ValueError("Each example must be a tuple of (document_snippet, expected_json)")
                 if not isinstance(ex[0], str) or not isinstance(ex[1], dict):
-                    raise ValueError("Each example must be a tuple of (str, dict)")
+                    raise TypeError("Each example must be a tuple of (str, dict)")
         return v
 
     @classmethod


### PR DESCRIPTION
## Summary

Fix the schema validator to raise TypeError when an example contains an invalid type.

## Changes

- Changed the second ValueError in Schema.validate_examples to TypeError.
- Verified the change with Ruff TRY004.
- Existing parser tests pass (20/20).

## Testing

- Ruff: passed
- tests/test_parser.py: 20 passed
- Full test suite: 73 passed, 1 pre-existing failure in test_catastrophic_backtracking_pattern_does_not_hang on Windows.