### PR TITLE
fix(cli): show friendly message when schema is omitted from extract (#33)

### DIFF
--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -51,7 +51,7 @@ SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | {".pdf"}
 @app.command()
 def extract(
     file: Path = typer.Argument(..., exists=True, readable=True, help="Path to the PDF/PNG/JPG document."),
-    schema: Path = typer.Argument(..., exists=True, readable=True, help="Path to a .json or .yaml schema file listing the fields to extract."),
+    schema: Optional[Path] = typer.Argument(None, help="Path to a .json or .yaml schema file listing the fields to extract."),
     model: str = typer.Option("gpt-4o-mini", "--model", "-m", help="Model name, e.g. gpt-4o-mini, llama3."),
     base_url: Optional[str] = typer.Option(None, "--base-url", help="OpenAI-compatible API base URL. Omit for OpenAI; use e.g. http://localhost:11434/v1 for Ollama."),
     api_key: Optional[str] = typer.Option(None, "--api-key", envvar="LLM_API_KEY", help="API key. Not needed for local Ollama."),
@@ -59,6 +59,26 @@ def extract(
     kind: Optional[str] = typer.Option(None, "--kind", help="Override ingestion routing (e.g. 'docx' for a custom handler loaded via FASTDOCPARSE_PLUGINS). Defaults to auto-detecting pdf/image from the file extension."),
 ):
     """Extract the fields defined in SCHEMA from FILE and print the result as JSON."""
+    if schema is None:
+        typer.echo(
+            "Error: a schema file is required.\n"
+            "\n"
+            "Quickest way to create one — describe your fields in plain English:\n"
+            "  fastdocparse schema-from-text \"invoice number, total amount, and line items\" --output my_schema.json\n"
+            "\n"
+            "Or start from a bundled example schema:\n"
+            "  fastdocparse list-schemas\n"
+            "\n"
+            "Then extract with:\n"
+            "  fastdocparse extract " + str(file) + " my_schema.json",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if not schema.exists():
+        typer.echo(f"Error: schema file not found: {schema}", err=True)
+        raise typer.Exit(code=1)
+
     if kind is None and file.suffix.lower() not in SUPPORTED_EXTENSIONS:
         typer.echo(f"Unsupported file type {file.suffix!r}. Supported: .pdf, .png, .jpg, .jpeg (or pass --kind).", err=True)
         raise typer.Exit(code=1)
@@ -134,6 +154,28 @@ def schema_from_text(
 
     typer.echo(f"Saved schema '{doc_schema.name}' with {len(doc_schema.fields)} field(s) to {output}")
     typer.echo("Review it, then run: fastdocparse extract <your_document> " + str(output))
+
+
+@app.command(name="list-schemas")
+def list_schemas():
+    """List the bundled example schemas you can copy as a starting point.
+
+    Copy any of the listed files into your project and pass the copy to `extract`.
+    This is the fastest way to get started without an LLM-generated schema.
+    """
+    schemas_dir = Path(__file__).parent / "schemas"
+    schema_files = sorted(schemas_dir.glob("*.json"))
+    if not schema_files:
+        typer.echo("No bundled schemas found.", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo("Bundled example schemas (copy one as your starting point):\n")
+    for path in schema_files:
+        typer.echo(f"  {path}")
+    typer.echo(
+        "\nTo use one directly:\n"
+        "  fastdocparse extract document.pdf " + str(schema_files[0])
+    )
 
 
 if __name__ == "__main__":

--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -73,7 +73,7 @@ def main(
 @app.command()
 def extract(
     file: Path = typer.Argument(..., exists=True, readable=True, help="Path to the PDF/PNG/JPG document."),
-    schema: Optional[Path] = typer.Argument(None, help="Path to a .json or .yaml schema file listing the fields to extract."),
+    schema: Path | None = typer.Argument(None, exists=True, readable=True, help="Path to a .json or .yaml schema file listing the fields to extract."),
     model: str = typer.Option("gpt-4o-mini", "--model", "-m", help="Model name, e.g. gpt-4o-mini, llama3."),
     base_url: str | None = typer.Option(None, "--base-url", help="OpenAI-compatible API base URL. Omit for OpenAI; use e.g. http://localhost:11434/v1 for Ollama."),
     api_key: str | None = typer.Option(None, "--api-key", envvar="LLM_API_KEY", help="API key. Not needed for local Ollama."),
@@ -95,10 +95,6 @@ def extract(
             "  fastdocparse extract " + str(file) + " my_schema.json",
             err=True,
         )
-        raise typer.Exit(code=1)
-
-    if not schema.exists():
-        typer.echo(f"Error: schema file not found: {schema}", err=True)
         raise typer.Exit(code=1)
 
     if kind is None and file.suffix.lower() not in SUPPORTED_EXTENSIONS:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,3 +127,21 @@ def test_schema_from_text_reports_generation_failure_cleanly(tmp_path):
     assert result.exit_code == 1
     assert "Could not generate a schema" in result.output
     assert not output_path.exists()
+
+
+def test_extract_command_missing_schema_shows_friendly_message():
+    """When schema is omitted, the user should see how to create one — not Typer's generic error."""
+    result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE)])
+
+    assert result.exit_code == 1
+    assert "schema file is required" in result.output
+    assert "schema-from-text" in result.output
+    assert "list-schemas" in result.output
+
+
+def test_list_schemas_shows_bundled_schemas():
+    """list-schemas should enumerate at least the invoice.json bundled example."""
+    result = runner.invoke(app, ["list-schemas"])
+
+    assert result.exit_code == 0
+    assert "invoice" in result.output.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,3 +153,19 @@ def test_list_schemas_shows_bundled_schemas():
 
     assert result.exit_code == 0
     assert "invoice" in result.output.lower()
+
+
+def test_extract_command_rejects_unreadable_schema_cleanly(tmp_path):
+    """A schema that exists but can't be read (permission denied) must fail with a clean
+    Typer-level error, not skip straight past the friendly-missing-schema path and crash
+    later with a raw OSError when the code tries to actually open it."""
+    unreadable_schema = tmp_path / "no_access.json"
+    unreadable_schema.write_text('{"name": "T", "fields": []}')
+    unreadable_schema.chmod(0o000)
+    try:
+        result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE), str(unreadable_schema)])
+    finally:
+        unreadable_schema.chmod(0o644)
+
+    assert result.exit_code != 0
+    assert "readable" in result.output.lower()


### PR DESCRIPTION
Closes #33.

### Problem
Running `fastdocparse extract document.pdf` with no schema argument showed Typer's generic "missing argument" error, giving new users no hint about what to do next.

### Solution
- Made `schema` an `Optional[Path]` argument (defaulting to `None`) with a manual check inside the function body.
- When schema is omitted, the command now prints a clear error that:
  1. Explains a schema file is required
  2. Points at `fastdocparse schema-from-text "..."` as the fastest way to generate one
  3. Mentions `fastdocparse list-schemas` to browse bundled examples
- Added a new `list-schemas` command that enumerates all bundled example schemas under `src/fastdocparse/schemas/` with their full paths, ready to copy-and-use.

### Tests
- `test_extract_command_missing_schema_shows_friendly_message` — asserts the new error message appears and references both `schema-from-text` and `list-schemas`
- `test_list_schemas_shows_bundled_schemas` — asserts `list-schemas` exits cleanly and lists `invoice.json`

All 11 `test_cli.py` tests pass.
