### PR TITLE
fix: clear Ruff lint findings

### DIFF
--- a/src/fastdocparse/__init__.py
+++ b/src/fastdocparse/__init__.py
@@ -30,33 +30,35 @@ from .schema import Field, Schema
 from .schema_compiler import compile_schema_from_description
 
 try:
+    from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as _pkg_version
+
     # Looks up by the PyPI *distribution* name (pyproject.toml's [project] name) — keep
     # this string in sync with that if the distribution is ever renamed again.
     __version__ = _pkg_version("fastdocparse")
-except Exception:
+except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
 __all__ = [
-    "Schema",
-    "Field",
-    "LLMClient",
-    "LLMClientError",
+    "Cache",
     "DocumentParser",
     "EmptyDocumentError",
-    "UnknownIngestionKindError",
-    "register_default_ingestion_handler",
     "ExtractionConfig",
-    "Cache",
-    "InMemoryCache",
-    "ExtractionResult",
-    "FieldResult",
     "ExtractionMeta",
+    "ExtractionResult",
+    "Field",
+    "FieldResult",
+    "InMemoryCache",
     "Issue",
+    "LLMClient",
+    "LLMClientError",
+    "Schema",
+    "UnknownIngestionKindError",
     "check_substring",
-    "cross_check",
-    "validate_field_constraints",
-    "numeric_sum_rule",
-    "date_parseable_rule",
     "compile_schema_from_description",
+    "cross_check",
+    "date_parseable_rule",
+    "numeric_sum_rule",
+    "register_default_ingestion_handler",
+    "validate_field_constraints",
 ]

--- a/src/fastdocparse/cache.py
+++ b/src/fastdocparse/cache.py
@@ -4,19 +4,20 @@ Caching is skipped whenever custom `rules` are passed to extract(), since a rule
 arbitrary callable that can't be safely fingerprinted — caching would risk returning a
 result validated under a different rule than the one just requested.
 """
+from __future__ import annotations
 
 import hashlib
 import json
 from collections import OrderedDict
-from typing import Any, Callable, Dict, Optional, Protocol
+from typing import Any, Callable, Protocol
 
 from .config import ExtractionConfig
 from .schema import Schema
 
 
 class Cache(Protocol):
-    def get(self, key: str) -> Optional[Dict[str, Any]]: ...
-    def set(self, key: str, value: Dict[str, Any]) -> None: ...
+    def get(self, key: str) -> dict[str, Any] | None: ...
+    def set(self, key: str, value: dict[str, Any]) -> None: ...
 
 
 class InMemoryCache:
@@ -27,19 +28,19 @@ class InMemoryCache:
     process exits before the cache could grow unbounded.
     """
 
-    def __init__(self, max_size: Optional[int] = None):
+    def __init__(self, max_size: int | None = None):
         if max_size is not None and max_size <= 0:
             raise ValueError(f"max_size must be positive, got {max_size}")
         self._max_size = max_size
-        self._store: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
+        self._store: OrderedDict[str, dict[str, Any]] = OrderedDict()
 
-    def get(self, key: str) -> Optional[Dict[str, Any]]:
+    def get(self, key: str) -> dict[str, Any] | None:
         if key not in self._store:
             return None
         self._store.move_to_end(key)
         return self._store[key]
 
-    def set(self, key: str, value: Dict[str, Any]) -> None:
+    def set(self, key: str, value: dict[str, Any]) -> None:
         self._store[key] = value
         self._store.move_to_end(key)
         if self._max_size is not None:

--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -4,12 +4,12 @@ Usage:
     fastdocparse extract document.pdf invoice_schema.json
     fastdocparse extract receipt.jpg shipment_schema.json --model llama3 --base-url http://localhost:11434/v1
 """
+from __future__ import annotations
 
 import importlib
 import json
 import os
 from pathlib import Path
-from typing import Optional
 
 import typer
 from pydantic import ValidationError
@@ -53,10 +53,10 @@ def extract(
     file: Path = typer.Argument(..., exists=True, readable=True, help="Path to the PDF/PNG/JPG document."),
     schema: Path = typer.Argument(..., exists=True, readable=True, help="Path to a .json or .yaml schema file listing the fields to extract."),
     model: str = typer.Option("gpt-4o-mini", "--model", "-m", help="Model name, e.g. gpt-4o-mini, llama3."),
-    base_url: Optional[str] = typer.Option(None, "--base-url", help="OpenAI-compatible API base URL. Omit for OpenAI; use e.g. http://localhost:11434/v1 for Ollama."),
-    api_key: Optional[str] = typer.Option(None, "--api-key", envvar="LLM_API_KEY", help="API key. Not needed for local Ollama."),
-    output: Optional[Path] = typer.Option(None, "--output", "-o", help="Write the JSON result to this file instead of printing it."),
-    kind: Optional[str] = typer.Option(None, "--kind", help="Override ingestion routing (e.g. 'docx' for a custom handler loaded via FASTDOCPARSE_PLUGINS). Defaults to auto-detecting pdf/image from the file extension."),
+    base_url: str | None = typer.Option(None, "--base-url", help="OpenAI-compatible API base URL. Omit for OpenAI; use e.g. http://localhost:11434/v1 for Ollama."),
+    api_key: str | None = typer.Option(None, "--api-key", envvar="LLM_API_KEY", help="API key. Not needed for local Ollama."),
+    output: Path | None = typer.Option(None, "--output", "-o", help="Write the JSON result to this file instead of printing it."),
+    kind: str | None = typer.Option(None, "--kind", help="Override ingestion routing (e.g. 'docx' for a custom handler loaded via FASTDOCPARSE_PLUGINS). Defaults to auto-detecting pdf/image from the file extension."),
 ):
     """Extract the fields defined in SCHEMA from FILE and print the result as JSON."""
     if kind is None and file.suffix.lower() not in SUPPORTED_EXTENSIONS:
@@ -109,8 +109,8 @@ def schema_from_text(
     description: str = typer.Argument(..., help="Plain-English description of the fields you want extracted, e.g. \"invoice number, total price, and a list of line items with product name and quantity\"."),
     output: Path = typer.Option(..., "--output", "-o", help="Where to save the generated schema (.json)."),
     model: str = typer.Option("gpt-4o-mini", "--model", "-m", help="Model name, e.g. gpt-4o-mini, llama3."),
-    base_url: Optional[str] = typer.Option(None, "--base-url", help="OpenAI-compatible API base URL. Omit for OpenAI; use e.g. http://localhost:11434/v1 for Ollama."),
-    api_key: Optional[str] = typer.Option(None, "--api-key", envvar="LLM_API_KEY", help="API key. Not needed for local Ollama."),
+    base_url: str | None = typer.Option(None, "--base-url", help="OpenAI-compatible API base URL. Omit for OpenAI; use e.g. http://localhost:11434/v1 for Ollama."),
+    api_key: str | None = typer.Option(None, "--api-key", envvar="LLM_API_KEY", help="API key. Not needed for local Ollama."),
 ):
     """Turn a plain-English description of the fields you want into a schema file.
 

--- a/src/fastdocparse/grounding.py
+++ b/src/fastdocparse/grounding.py
@@ -1,12 +1,13 @@
 """Grounding and validation checks for extracted data."""
+from __future__ import annotations
 
 import logging
 import re
 import signal
 import threading
 from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
 
 from .schema import Schema
 
@@ -27,7 +28,7 @@ class _PatternTimeout(Exception):
     pass
 
 
-def _regex_matches_with_timeout(pattern: str, value: str, timeout: float = 1.0) -> Optional[bool]:
+def _regex_matches_with_timeout(pattern: str, value: str, timeout: float = 1.0) -> bool | None:
     """Guard re.fullmatch against a catastrophically backtracking pattern (e.g.
     "^(a+)+$" against a long near-miss string), since `pattern` is arbitrary user- or
     LLM-supplied regex that can otherwise hang indefinitely.
@@ -83,13 +84,13 @@ class Issue:
     kind: str = "cross_check"  # "cross_check" | "missing_required" | "invalid_format"
 
 
-CrossCheckRule = Callable[[Dict[str, Any]], Optional[List[Issue]]]
+CrossCheckRule = Callable[[dict[str, Any]], Optional[list[Issue]]]
 
 
 _NUMBER_RE = re.compile(r'-?\d[\d,]*\.?\d*')
 
 
-def _as_number(value: Any) -> Optional[float]:
+def _as_number(value: Any) -> float | None:
     """Parse an int/float or a numeric-looking string (currency symbols, thousands separators) into a float."""
     if isinstance(value, bool):
         return None
@@ -104,7 +105,7 @@ def _as_number(value: Any) -> Optional[float]:
     return None
 
 
-def _extract_numbers(text: str) -> List[float]:
+def _extract_numbers(text: str) -> list[float]:
     numbers = []
     for match in _NUMBER_RE.findall(text):
         try:
@@ -134,7 +135,7 @@ def _parse_date_any(text: str):
     text = text.strip()
     for fmt in _DATE_FORMATS:
         try:
-            return datetime.strptime(text, fmt).date()
+            return datetime.strptime(text, fmt).replace(tzinfo=timezone.utc).date()
         except ValueError:
             continue
     return None
@@ -200,13 +201,13 @@ def check_substring(value: Any, source_text: str, numeric: bool = False, date: b
     return bool(val_clean and val_clean in source_clean)
 
 
-def validate_field_constraints(schema: Schema, extracted: Dict[str, Any]) -> List[Issue]:
+def validate_field_constraints(schema: Schema, extracted: dict[str, Any]) -> list[Issue]:
     """Check schema-declared constraints (required, pattern, enum) against extracted values.
 
     Runs automatically for every schema, independent of any user-supplied cross_check rules —
     these constraints are properties of the schema itself (any domain), not custom business logic.
     """
-    issues: List[Issue] = []
+    issues: list[Issue] = []
     for f in schema.fields:
         value = extracted.get(f.name)
         is_missing = not _is_present(value) or (f.type == "list" and not value)
@@ -244,7 +245,7 @@ def validate_field_constraints(schema: Schema, extracted: Dict[str, Any]) -> Lis
 def numeric_sum_rule(list_field: str, total_field: str, item_key: str = "amount", tolerance: float = 0.01) -> CrossCheckRule:
     """Build a rule flagging total_field when it doesn't match the sum of item_key across list_field."""
 
-    def _rule(extracted: Dict[str, Any]) -> Optional[List[Issue]]:
+    def _rule(extracted: dict[str, Any]) -> list[Issue] | None:
         total = extracted.get(total_field)
         items = extracted.get(list_field)
         if total is None or not items:
@@ -264,19 +265,17 @@ def numeric_sum_rule(list_field: str, total_field: str, item_key: str = "amount"
     return _rule
 
 
-def date_parseable_rule(field_name: str, formats: Optional[List[str]] = None) -> CrossCheckRule:
+def date_parseable_rule(field_name: str, formats: list[str] | None = None) -> CrossCheckRule:
     """Build a rule flagging field_name when its value doesn't parse as a date in any given format."""
-    from datetime import datetime
-
     candidates = formats or ["%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y", "%Y/%m/%d"]
 
-    def _rule(extracted: Dict[str, Any]) -> Optional[List[Issue]]:
+    def _rule(extracted: dict[str, Any]) -> list[Issue] | None:
         val = extracted.get(field_name)
         if val is None:
             return None
         for fmt in candidates:
             try:
-                datetime.strptime(str(val), fmt)
+                datetime.strptime(str(val), fmt).replace(tzinfo=timezone.utc)
                 return None
             except ValueError:
                 continue
@@ -285,12 +284,12 @@ def date_parseable_rule(field_name: str, formats: Optional[List[str]] = None) ->
     return _rule
 
 
-def cross_check(schema: Schema, extracted: Dict[str, Any], rules: Optional[List[CrossCheckRule]]) -> List[Issue]:
+def cross_check(schema: Schema, extracted: dict[str, Any], rules: list[CrossCheckRule] | None) -> list[Issue]:
     """
     Run custom cross-check rules on the extracted data.
     Each rule is a callable taking the extracted dict and returning a list of Issues (or None).
     """
-    issues: List[Issue] = []
+    issues: list[Issue] = []
     if not rules:
         return issues
 

--- a/src/fastdocparse/json_repair.py
+++ b/src/fastdocparse/json_repair.py
@@ -1,11 +1,14 @@
 """Recover a JSON object from raw LLM output that isn't guaranteed to be clean JSON."""
 
 import json
+import logging
 import re
-from typing import Any, Dict
+from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
-def parse_json_from_llm(text: str) -> Dict[str, Any]:
+def parse_json_from_llm(text: str) -> dict[str, Any]:
     """Safely parse JSON from LLM output, handling markdown blocks and `<think>` tags."""
     text = text.strip()
     text = re.sub(r"<think\b[^>]*>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
@@ -14,8 +17,8 @@ def parse_json_from_llm(text: str) -> Dict[str, Any]:
     if match:
         try:
             return json.loads(match.group(1).strip())
-        except Exception:
-            pass
+        except json.JSONDecodeError:
+            logger.debug("Ignoring invalid fenced JSON in LLM output.", exc_info=True)
 
     brace_positions = [i for i, c in enumerate(text) if c == "{"]
     for pos in reversed(brace_positions):
@@ -25,7 +28,8 @@ def parse_json_from_llm(text: str) -> Dict[str, Any]:
                 obj = json.loads(text[pos:end + 1])
                 if isinstance(obj, dict):
                     return obj
-            except Exception:
+            except json.JSONDecodeError:
+                logger.debug("Skipping invalid JSON candidate in LLM output.", exc_info=True)
                 continue
 
     # Nothing above found valid JSON — likely the response was cut off mid-object
@@ -35,7 +39,7 @@ def parse_json_from_llm(text: str) -> Dict[str, Any]:
     return _repair_truncated_json(text)
 
 
-def _repair_truncated_json(text: str) -> Dict[str, Any]:
+def _repair_truncated_json(text: str) -> dict[str, Any]:
     start = text.find("{")
     if start == -1:
         return {}
@@ -75,5 +79,5 @@ def _repair_truncated_json(text: str) -> Dict[str, Any]:
     try:
         obj = json.loads(repaired)
         return obj if isinstance(obj, dict) else {}
-    except Exception:
+    except json.JSONDecodeError:
         return {}

--- a/src/fastdocparse/llm_client.py
+++ b/src/fastdocparse/llm_client.py
@@ -1,7 +1,7 @@
 """OpenAI-compatible LLM client for document extraction."""
+from __future__ import annotations
 
 import time
-from typing import List, Optional
 
 from openai import (
     APIConnectionError,
@@ -20,7 +20,7 @@ class LLMClientError(Exception):
 class LLMClient:
     """A thin adapter over any OpenAI-compatible endpoint."""
 
-    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None, model: Optional[str] = None):
+    def __init__(self, base_url: str | None = None, api_key: str | None = None, model: str | None = None):
         """Initialize the LLM client.
 
         Args:
@@ -39,9 +39,9 @@ class LLMClient:
             timeout=60.0
         )
 
-    def _call(self, messages: List[ChatCompletionMessageParam], temperature: float, max_tokens: int, retries: int = 2, backoff: float = 1.0) -> str:
+    def _call(self, messages: list[ChatCompletionMessageParam], temperature: float, max_tokens: int, retries: int = 2, backoff: float = 1.0) -> str:
         """Run a chat completion, retrying transient failures and raising LLMClientError on exhaustion."""
-        last_error: Optional[Exception] = None
+        last_error: Exception | None = None
         for attempt in range(retries + 1):
             try:
                 response = self.client.chat.completions.create(

--- a/src/fastdocparse/ocr_engine.py
+++ b/src/fastdocparse/ocr_engine.py
@@ -6,7 +6,6 @@ import importlib.util
 import io
 import logging
 import threading
-from typing import List, Tuple
 
 from PIL import Image
 
@@ -34,8 +33,9 @@ def _get_rapid_ocr():
             return _rapid_ocr
         try:
             from rapidocr_onnxruntime import RapidOCR
+
             _rapid_ocr = RapidOCR()
-        except Exception:
+        except (ImportError, OSError, RuntimeError, ValueError):
             logger.warning("RapidOCR failed to initialize; OCR extraction will return empty text.", exc_info=True)
             _init_failed = True
     return _rapid_ocr
@@ -72,7 +72,7 @@ def extract_text_from_image_ocr(image_bytes: bytes, structured_mode: bool = Fals
         if not result:
             return ""
 
-        lines: List[Tuple[float, float, str]] = []
+        lines: list[tuple[float, float, str]] = []
         for box, text, conf in result:
             conf_val = float(conf) if conf is not None else 0.0
             if conf_val > min_confidence and text and str(text).strip():
@@ -82,9 +82,9 @@ def extract_text_from_image_ocr(image_bytes: bytes, structured_mode: bool = Fals
 
         lines.sort(key=lambda item: (round(item[0] / 15), item[1]))
 
-        grouped_lines: List[str] = []
+        grouped_lines: list[str] = []
         current_y_group = -1
-        current_line_parts: List[str] = []
+        current_line_parts: list[str] = []
 
         for y0, x0, text in lines:
             group = round(y0 / 15)
@@ -105,5 +105,5 @@ def extract_text_from_image_ocr(image_bytes: bytes, structured_mode: bool = Fals
             grouped_lines.append("    ".join(current_line_parts))
 
         return "\n".join(grouped_lines)
-    except Exception:
+    except (OSError, RuntimeError, TypeError, ValueError):
         return ""

--- a/src/fastdocparse/parser.py
+++ b/src/fastdocparse/parser.py
@@ -1,11 +1,12 @@
 """Parser module orchestrating document extraction."""
+from __future__ import annotations
 
 import asyncio
 import functools
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable
 
 import pymupdf
 
@@ -55,7 +56,7 @@ class UnknownIngestionKindError(ValueError):
     """
 
 
-def _merge_extracted_data(results: List[Dict[str, Any]], chunks: List[str], schema: Schema) -> Dict[str, Any]:
+def _merge_extracted_data(results: list[dict[str, Any]], chunks: list[str], schema: Schema) -> dict[str, Any]:
     """Merge per-chunk extractions into one result.
 
     List fields concatenate across chunks (unchanged). For scalar fields, when more than
@@ -68,7 +69,7 @@ def _merge_extracted_data(results: List[Dict[str, Any]], chunks: List[str], sche
     if not results:
         return {}
 
-    merged: Dict[str, Any] = {}
+    merged: dict[str, Any] = {}
     for f in schema.fields:
         merged[f.name] = [] if f.type == "list" else None
 
@@ -122,7 +123,7 @@ def _ingest_image(document_bytes: bytes, structured_mode: bool, config: Extracti
     )
 
 
-INGESTION_HANDLERS: Dict[str, Callable[[bytes, bool, ExtractionConfig], str]] = {
+INGESTION_HANDLERS: dict[str, Callable[[bytes, bool, ExtractionConfig], str]] = {
     "pdf": _ingest_pdf,
     "image": _ingest_image,
 }
@@ -151,9 +152,9 @@ class DocumentParser:
     def __init__(
         self,
         client: LLMClient,
-        config: Optional[ExtractionConfig] = None,
-        cache: Optional[Cache] = None,
-        ingestion_handlers: Optional[Dict[str, Callable[[bytes, bool, ExtractionConfig], str]]] = None,
+        config: ExtractionConfig | None = None,
+        cache: Cache | None = None,
+        ingestion_handlers: dict[str, Callable[[bytes, bool, ExtractionConfig], str]] | None = None,
     ):
         self.client = client
         self.config = config or ExtractionConfig()
@@ -171,9 +172,9 @@ class DocumentParser:
         document_bytes: bytes,
         schema: Schema,
         is_image: bool = False,
-        rules: Optional[List[CrossCheckRule]] = None,
-        kind: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        rules: list[CrossCheckRule] | None = None,
+        kind: str | None = None,
+    ) -> dict[str, Any]:
         """Extract information from a document matching the schema.
 
         kind overrides routing when set (must be registered via register_ingestion_handler
@@ -223,9 +224,9 @@ class DocumentParser:
         document_bytes: bytes,
         schema: Schema,
         is_image: bool = False,
-        rules: Optional[List[CrossCheckRule]] = None,
-        kind: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        rules: list[CrossCheckRule] | None = None,
+        kind: str | None = None,
+    ) -> dict[str, Any]:
         """Async wrapper around extract(). The work itself is still synchronous (OCR,
         PDF parsing, and the LLM SDK calls are all blocking) — this runs it in a
         background thread so an asyncio event loop (e.g. inside a FastAPI route) isn't
@@ -241,7 +242,7 @@ class DocumentParser:
             raise UnknownIngestionKindError(f"No ingestion handler registered for document kind {kind!r}")
         return handler
 
-    def _check_truncation(self, document_bytes: bytes, kind: str) -> tuple[bool, Optional[str]]:
+    def _check_truncation(self, document_bytes: bytes, kind: str) -> tuple[bool, str | None]:
         if kind != "pdf":
             return False, None
         try:
@@ -252,10 +253,10 @@ class DocumentParser:
                 return False, None
             finally:
                 doc.close()
-        except Exception:
+        except (pymupdf.EmptyFileError, pymupdf.FileDataError, RuntimeError):
             return False, None
 
-    def _run_extraction(self, chunks: List[str], schema: Schema) -> Dict[str, Any]:
+    def _run_extraction(self, chunks: list[str], schema: Schema) -> dict[str, Any]:
         prompt_template = compile_prompt(schema)
         max_workers = self.config.max_concurrent_chunks
 
@@ -264,7 +265,7 @@ class DocumentParser:
             # involved — keeps behavior (and mock call ordering in tests) unchanged.
             parsed_chunks = [_parse_json_from_llm(self.client.extract(prompt_template, chunk)) for chunk in chunks]
         else:
-            def process(chunk: str) -> Dict[str, Any]:
+            def process(chunk: str) -> dict[str, Any]:
                 return _parse_json_from_llm(self.client.extract(prompt_template, chunk))
 
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -275,14 +276,14 @@ class DocumentParser:
     def _build_result(
         self,
         schema: Schema,
-        merged_data: Dict[str, Any],
+        merged_data: dict[str, Any],
         doc_text: str,
-        rules: Optional[list],
+        rules: list | None,
         is_truncated: bool,
-        truncation_reason: Optional[str],
-    ) -> Dict[str, Any]:
+        truncation_reason: str | None,
+    ) -> dict[str, Any]:
         issues = cross_check(schema, merged_data, rules) + validate_field_constraints(schema, merged_data)
-        issues_by_field: Dict[str, List[Issue]] = {}
+        issues_by_field: dict[str, list[Issue]] = {}
         for issue in issues:
             issues_by_field.setdefault(issue.field, []).append(issue)
         issue_kind_to_flag = {
@@ -291,7 +292,7 @@ class DocumentParser:
             "invalid_format": "invalid_format",
         }
 
-        final_result: Dict[str, Any] = {
+        final_result: dict[str, Any] = {
             "_meta": {
                 "truncated": is_truncated,
                 "truncation_reason": truncation_reason,

--- a/src/fastdocparse/pdf_utils.py
+++ b/src/fastdocparse/pdf_utils.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 import io
+import logging
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
 
 import pymupdf  # PyMuPDF
 from PIL import Image
 
 # Rendering constants
 PDF_RENDER_DPI = 150
+logger = logging.getLogger(__name__)
 
 
-def _safe_open_pdf(pdf_bytes: bytes) -> Optional["pymupdf.Document"]:
+def _safe_open_pdf(pdf_bytes: bytes) -> pymupdf.Document | None:
     """pymupdf.open() raises pymupdf.FileDataError/EmptyFileError (both RuntimeError
     subclasses, not ValueError) on corrupt or non-PDF bytes — a raw file upload gone
     wrong is an expected, common failure mode here, not a programming error, so it
@@ -21,7 +22,7 @@ def _safe_open_pdf(pdf_bytes: bytes) -> Optional["pymupdf.Document"]:
     that the same as "no text found," which the rest of the pipeline already handles."""
     try:
         return pymupdf.open(stream=pdf_bytes, filetype="pdf")
-    except Exception:
+    except (pymupdf.EmptyFileError, pymupdf.FileDataError, RuntimeError):
         return None
 
 
@@ -34,12 +35,12 @@ class PageImage:
     height: int         # image height in pixels
 
 
-def pdf_to_page_images(pdf_bytes: bytes, max_pages: int = 3, dpi: int = PDF_RENDER_DPI, max_dim: int = 1536) -> List[PageImage]:
+def pdf_to_page_images(pdf_bytes: bytes, max_pages: int = 3, dpi: int = PDF_RENDER_DPI, max_dim: int = 1536) -> list[PageImage]:
     """Render up to max_pages of a PDF to a PNG image at the given DPI.
 
     Returns a list of PageImage in page order.
     """
-    pages: List[PageImage] = []
+    pages: list[PageImage] = []
     doc = _safe_open_pdf(pdf_bytes)
     if doc is None:
         return pages
@@ -98,7 +99,7 @@ def image_bytes_to_page_image(img_bytes: bytes) -> PageImage:
     return PageImage(index=0, png_bytes=buf.getvalue(), width=img.width, height=img.height)
 
 
-def _grid_to_markdown(grid: List[List[str]]) -> str:
+def _grid_to_markdown(grid: list[list[str]]) -> str:
     """Convert a 2D table array into a clean Markdown table string."""
     if not grid or not grid[0]:
         return ""
@@ -116,7 +117,7 @@ def _grid_to_markdown(grid: List[List[str]]) -> str:
     return "\n".join(lines)
 
 
-def _bbox_overlaps(b1: Tuple[float, float, float, float], b2: Tuple[float, float, float, float], thresh: float = 0.5) -> bool:
+def _bbox_overlaps(b1: tuple[float, float, float, float], b2: tuple[float, float, float, float], thresh: float = 0.5) -> bool:
     """Check if block b1 overlaps significantly with table bbox b2."""
     x0 = max(b1[0], b2[0])
     y0 = max(b1[1], b2[1])
@@ -132,7 +133,7 @@ def _bbox_overlaps(b1: Tuple[float, float, float, float], b2: Tuple[float, float
 def extract_layout_markdown_from_pdf(pdf_bytes: bytes, max_pages: int = 15, structured_mode: bool = False) -> str:
     """Phase 1 Engine: Extract digital PDF into layout-preserved Markdown text."""
     doc = _safe_open_pdf(pdf_bytes)
-    pages_md: List[str] = []
+    pages_md: list[str] = []
     if doc is None:
         return ""
     try:
@@ -140,8 +141,8 @@ def extract_layout_markdown_from_pdf(pdf_bytes: bytes, max_pages: int = 15, stru
             page = doc[i]
             
             # 1. Extract tables
-            table_bboxes: List[Tuple[float, float, float, float]] = []
-            table_markdowns: List[Tuple[float, str]] = []  # (y0, markdown_str)
+            table_bboxes: list[tuple[float, float, float, float]] = []
+            table_markdowns: list[tuple[float, str]] = []  # (y0, markdown_str)
             try:
                 tabs = page.find_tables()
                 for tab in tabs.tables:
@@ -150,12 +151,12 @@ def extract_layout_markdown_from_pdf(pdf_bytes: bytes, max_pages: int = 15, stru
                     if md:
                         table_bboxes.append(tab.bbox)
                         table_markdowns.append((tab.bbox[1], md))
-            except Exception:
-                pass
+            except (RuntimeError, TypeError, ValueError):
+                logger.debug("Skipping failed PDF table extraction.", exc_info=True)
 
             # 2. Extract text blocks outside tables
             blocks = page.get_text("blocks")
-            non_table_blocks: List[Tuple[float, float, str]] = []  # (y0, x0, text)
+            non_table_blocks: list[tuple[float, float, str]] = []  # (y0, x0, text)
             for b in blocks:
                 if len(b) >= 5 and b[4].strip():
                     bbox = (b[0], b[1], b[2], b[3])
@@ -167,7 +168,7 @@ def extract_layout_markdown_from_pdf(pdf_bytes: bytes, max_pages: int = 15, stru
                             non_table_blocks.append((b[1], b[0], b[4].strip()))
 
             # 3. Merge blocks & tables spatially top-to-bottom
-            all_elements: List[Tuple[float, float, str]] = []
+            all_elements: list[tuple[float, float, str]] = []
             for y0, x0, text in non_table_blocks:
                 all_elements.append((y0, x0, text))
             for y0, md in table_markdowns:
@@ -192,7 +193,7 @@ def extract_text_from_pdf(pdf_bytes: bytes, max_pages: int = 15, structured_mode
     
     # Fallback to plain text
     doc = _safe_open_pdf(pdf_bytes)
-    texts: List[str] = []
+    texts: list[str] = []
     if doc is None:
         return ""
     try:
@@ -221,7 +222,7 @@ def is_digital_pdf(pdf_bytes: bytes, min_chars: int = 80) -> bool:
     return False
 
 
-def chunk_document_text(text: str, max_tokens: int = 3000) -> List[str]:
+def chunk_document_text(text: str, max_tokens: int = 3000) -> list[str]:
     """
     Split document text into chunks based on page delimiters.
     Approximates tokens via character count (4 chars ~ 1 token).

--- a/src/fastdocparse/pdf_utils.py
+++ b/src/fastdocparse/pdf_utils.py
@@ -146,13 +146,17 @@ def extract_layout_markdown_from_pdf(pdf_bytes: bytes, max_pages: int = 15, stru
             try:
                 tabs = page.find_tables()
                 for tab in tabs.tables:
-                    grid = tab.extract()
+                    try:
+                        grid = tab.extract()
+                    except (RuntimeError, TypeError, ValueError):
+                        logger.debug("Skipping failed PDF table extraction.", exc_info=True)
+                        continue
                     md = _grid_to_markdown(grid)
                     if md:
                         table_bboxes.append(tab.bbox)
                         table_markdowns.append((tab.bbox[1], md))
             except (RuntimeError, TypeError, ValueError):
-                logger.debug("Skipping failed PDF table extraction.", exc_info=True)
+                logger.debug("Skipping failed PDF table discovery.", exc_info=True)
 
             # 2. Extract text blocks outside tables
             blocks = page.get_text("blocks")

--- a/src/fastdocparse/prompt_compiler.py
+++ b/src/fastdocparse/prompt_compiler.py
@@ -1,14 +1,14 @@
 """Prompt compiler for generating dynamic Chain-of-Thought prompts from schemas."""
 
 import json
-from typing import Any, Dict
+from typing import Any
 
 from .schema import Field, Schema
 
 
-def _generate_json_structure(fields: list[Field]) -> Dict[str, Any]:
+def _generate_json_structure(fields: list[Field]) -> dict[str, Any]:
     """Generate a sample JSON structure representing the schema."""
-    structure: Dict[str, Any] = {}
+    structure: dict[str, Any] = {}
     for f in fields:
         if f.type == "list" and f.sub_fields:
             structure[f.name] = [_generate_json_structure(f.sub_fields)]

--- a/src/fastdocparse/result.py
+++ b/src/fastdocparse/result.py
@@ -9,8 +9,9 @@ and validation instead of raw dict indexing:
     typed = ExtractionResult.from_raw(result)
     typed.fields["invoice_number"].value
 """
+from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -18,20 +19,20 @@ from pydantic import BaseModel
 class FieldResult(BaseModel):
     value: Any
     confidence: str
-    flags: List[str]
+    flags: list[str]
 
 
 class ExtractionMeta(BaseModel):
     truncated: bool
-    truncation_reason: Optional[str] = None
+    truncation_reason: str | None = None
 
 
 class ExtractionResult(BaseModel):
     meta: ExtractionMeta
-    fields: Dict[str, FieldResult]
+    fields: dict[str, FieldResult]
 
     @classmethod
-    def from_raw(cls, raw: Dict[str, Any]) -> "ExtractionResult":
+    def from_raw(cls, raw: dict[str, Any]) -> ExtractionResult:
         """Build a typed result from the dict returned by DocumentParser.extract()."""
         raw = dict(raw)
         meta = raw.pop("_meta", None)

--- a/src/fastdocparse/schema.py
+++ b/src/fastdocparse/schema.py
@@ -1,8 +1,9 @@
 """Schema definitions for document extraction."""
+from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from pydantic import BaseModel, field_validator
 
@@ -13,9 +14,9 @@ class Field(BaseModel):
     description: str
     type: str = "text"  # "text", "number", "date", "currency", "list"
     required: bool = False
-    pattern: Optional[str] = None  # regex the extracted string value must fully match, e.g. HS/container codes
-    enum: Optional[List[str]] = None  # allowed values, e.g. shipment status, incoterms
-    sub_fields: Optional[List['Field']] = None
+    pattern: str | None = None  # regex the extracted string value must fully match, e.g. HS/container codes
+    enum: list[str] | None = None  # allowed values, e.g. shipment status, incoterms
+    sub_fields: list[Field] | None = None
 
     @property
     def is_numeric(self) -> bool:
@@ -34,8 +35,8 @@ class Field(BaseModel):
 class Schema(BaseModel):
     """Defines a complete document schema."""
     name: str = "DocumentSchema"
-    fields: List[Field]
-    examples: Optional[List[Tuple[str, Dict[str, Any]]]] = None
+    fields: list[Field]
+    examples: list[tuple[str, dict[str, Any]]] | None = None
 
     @field_validator('fields')
     @classmethod
@@ -59,18 +60,18 @@ class Schema(BaseModel):
         return v
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Schema":
+    def from_dict(cls, data: dict[str, Any]) -> Schema:
         """Build a Schema from a plain dict (as loaded from JSON/YAML) — no Python code needed."""
         return cls.model_validate(data)
 
     @classmethod
-    def from_json(cls, path: Union[str, Path]) -> "Schema":
+    def from_json(cls, path: str | Path) -> Schema:
         """Load a Schema from a .json file."""
         with open(path, "r") as f:
             return cls.from_dict(json.load(f))
 
     @classmethod
-    def from_yaml(cls, path: Union[str, Path]) -> "Schema":
+    def from_yaml(cls, path: str | Path) -> Schema:
         """Load a Schema from a .yaml/.yml file."""
         import yaml  # optional dependency; only needed for this path
 
@@ -78,7 +79,7 @@ class Schema(BaseModel):
             return cls.from_dict(yaml.safe_load(f))
 
     @classmethod
-    def from_file(cls, path: Union[str, Path]) -> "Schema":
+    def from_file(cls, path: str | Path) -> Schema:
         """Load a Schema from a .json or .yaml/.yml file, dispatching on extension."""
         path = Path(path)
         suffix = path.suffix.lower()
@@ -88,7 +89,7 @@ class Schema(BaseModel):
             return cls.from_json(path)
         raise ValueError(f"Unsupported schema file extension {suffix!r} (expected .json, .yaml, or .yml)")
 
-    def get_field(self, name: str) -> Optional[Field]:
+    def get_field(self, name: str) -> Field | None:
         for f in self.fields:
             if f.name == name:
                 return f

--- a/src/fastdocparse/schema_compiler.py
+++ b/src/fastdocparse/schema_compiler.py
@@ -12,7 +12,7 @@ a hallucinated schema silently corrupts every later run, so this is meant as
 an authoring aid with a human in the loop, not a fully implicit step.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 from .json_repair import parse_json_from_llm
 from .llm_client import LLMClient
@@ -57,7 +57,7 @@ def compile_schema_from_description(description: str, client: LLMClient) -> Sche
     """Turn a natural-language description into a Schema via one LLM call."""
     prompt = SCHEMA_GEN_PROMPT.format(description=description)
     raw_response = client.complete(prompt)
-    data: Dict[str, Any] = parse_json_from_llm(raw_response)
+    data: dict[str, Any] = parse_json_from_llm(raw_response)
 
     if not data or not data.get("fields"):
         raise ValueError(

--- a/tests/test_severe_edge_cases.py
+++ b/tests/test_severe_edge_cases.py
@@ -13,7 +13,7 @@ import pytest
 from fastdocparse.grounding import validate_field_constraints
 from fastdocparse.json_repair import parse_json_from_llm
 from fastdocparse.parser import DocumentParser, EmptyDocumentError
-from fastdocparse.pdf_utils import chunk_document_text
+from fastdocparse.pdf_utils import chunk_document_text, extract_layout_markdown_from_pdf
 from fastdocparse.schema import Field, Schema
 
 
@@ -131,3 +131,52 @@ def test_json_with_literal_braces_inside_string_values():
     raw = '{"description": "Use {curly} braces and {more} braces", "total": 100}'
     result = parse_json_from_llm(raw)
     assert result == {"description": "Use {curly} braces and {more} braces", "total": 100}
+
+
+def test_partial_table_data_survives_late_table_extraction_failure():
+    class FakeTable:
+        def __init__(self, bbox, grid=None, error=None):
+            self.bbox = bbox
+            self._grid = grid
+            self._error = error
+
+        def extract(self):
+            if self._error is not None:
+                raise self._error
+            return self._grid
+
+    class FakePage:
+        def find_tables(self):
+            return MagicMock(
+                tables=[
+                    FakeTable((0.0, 0.0, 100.0, 50.0), grid=[["A", "B"], ["1", "2"]]),
+                    FakeTable((0.0, 60.0, 100.0, 110.0), error=ValueError("broken table")),
+                ]
+            )
+
+        def get_text(self, mode):
+            assert mode == "blocks"
+            return [
+                (10.0, 10.0, 20.0, 20.0, "inside table", 0, 0),
+                (10.0, 120.0, 20.0, 130.0, "outside table", 0, 0),
+            ]
+
+    class FakeDoc:
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, index):
+            assert index == 0
+            return FakePage()
+
+        def close(self):
+            return None
+
+    with patch("fastdocparse.pdf_utils._safe_open_pdf", return_value=FakeDoc()):
+        markdown = extract_layout_markdown_from_pdf(b"pdf")
+
+    assert "| A | B |" in markdown
+    assert "| --- | --- |" in markdown
+    assert "| 1 | 2 |" in markdown
+    assert "outside table" in markdown
+    assert "inside table" not in markdown

--- a/tests/test_severe_edge_cases.py
+++ b/tests/test_severe_edge_cases.py
@@ -41,7 +41,7 @@ def test_catastrophic_backtracking_pattern_does_not_hang():
         "print(f'ELAPSED={time.time() - start}')\n"
     )
     # Generous outer bound — this only needs to catch a genuine hang, not time the guard.
-    result = subprocess.run([sys.executable, "-c", code], timeout=30, capture_output=True, text=True)
+    result = subprocess.run([sys.executable, "-c", code], timeout=30, capture_output=True, text=True, check=False)
     assert result.returncode == 0, result.stderr
 
     elapsed_line = next(line for line in result.stdout.splitlines() if line.startswith("ELAPSED="))


### PR DESCRIPTION
## Summary

- attach UTC timezone info to date parsing in grounding helpers
- modernize type annotations and sort exported names for Ruff
- narrow broad exception handlers to expected parsing/OCR/PDF failure modes
- add explicit `check=False` to the subprocess test call

Closes #12
Closes #13
Closes #15
Closes #11

## Validation

- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/pytest -v`