### PR TITLE
docs: add docstrings to FieldResult, ExtractionMeta, ExtractionResult

### DIFF
--- a/src/fastdocparse/result.py
+++ b/src/fastdocparse/result.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 
 
 class FieldResult(BaseModel):
-     """Typed result for a single extracted field.
+    """Typed result for a single extracted field.
 
     Attributes:
         value: The extracted value, or None if not found.
@@ -29,7 +29,6 @@ class FieldResult(BaseModel):
     value: Any
     confidence: str
     flags: list[str]
-   
 
 
 class ExtractionMeta(BaseModel):

--- a/src/fastdocparse/result.py
+++ b/src/fastdocparse/result.py
@@ -17,17 +17,50 @@ from pydantic import BaseModel
 
 
 class FieldResult(BaseModel):
+     """Typed result for a single extracted field.
+
+    Attributes:
+        value: The extracted value, or None if not found.
+        confidence: Extraction confidence level — 'high' if grounded in
+            source text, 'low' otherwise.
+        flags: List of status flags, e.g. 'grounded', 'ungrounded',
+            'missing_required', 'invalid_format', 'failed_check'.
+    """
     value: Any
     confidence: str
     flags: list[str]
+   
 
 
 class ExtractionMeta(BaseModel):
+    """Metadata about the extraction run.
+
+    Attributes:
+        truncated: True if the document exceeded max_pages and was truncated.
+        truncation_reason: Human-readable explanation of truncation, or None
+            if the document was processed in full.
+    """
     truncated: bool
     truncation_reason: str | None = None
 
 
 class ExtractionResult(BaseModel):
+    """Typed view of the dict returned by DocumentParser.extract().
+
+    Prefer this over raw dict indexing when you want attribute access,
+    IDE autocompletion, and Pydantic validation on the extraction output.
+
+    Example::
+
+        result = parser.extract(document_bytes, schema)
+        typed = ExtractionResult.from_raw(result)
+        print(typed.fields["invoice_number"].value)
+        print(typed.meta.truncated)
+
+    Attributes:
+        meta: Extraction metadata (truncation info).
+        fields: Per-field results keyed by field name.
+    """
     meta: ExtractionMeta
     fields: dict[str, FieldResult]
 


### PR DESCRIPTION
Closes #38

Added class-level docstrings to the three public classes in result.py 
that were missing them:

- `FieldResult` — documents value, confidence, and flags attributes
- `ExtractionMeta` — documents truncated and truncation_reason attributes  
- `ExtractionResult` — documents usage with an example, meta and fields attributes

All other classes in the public API (Field, Schema, DocumentParser, 
EmptyDocumentError, UnknownIngestionKindError) already had docstrings.
