### PR TITLE
Proofread pass: fix stale facts across README and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ git push -u origin your-branch-name
 gh pr create   # or open the PR on github.com
 ```
 
-CI (`test (3.10)`, `test (3.12)`) must pass before a PR can merge — that's also enforced, not optional. Once it's green, merge the PR (squash or regular merge, your call) rather than merging locally and pushing `main` directly.
+CI (`test (3.10)`, `test (3.12)`, `build`, `Analyze (python)`) must pass before a PR can merge — that's also enforced, not optional. Once it's green, merge the PR (squash or regular merge, your call) rather than merging locally and pushing `main` directly.
 
 ## Setup
 
@@ -27,7 +27,7 @@ pip install -e ".[dev]"
 pytest -v
 ```
 
-All 74 tests should pass before you open a PR. CI runs this automatically on every push and PR, but running it locally first saves a round-trip.
+All 75 tests should pass before you open a PR. CI runs this automatically on every push and PR, but running it locally first saves a round-trip.
 
 ## Before opening a PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Workflow
 
-**No direct pushes to `main`** — this is enforced by branch protection (including for repo admins), not just a convention. All changes go through a pull request:
+**No direct pushes to `main`.** This is enforced by branch protection (including for repo admins), not just a convention. All changes go through a pull request:
 
 ```bash
 git checkout -b your-branch-name
@@ -11,7 +11,7 @@ git push -u origin your-branch-name
 gh pr create   # or open the PR on github.com
 ```
 
-CI (`test (3.10)`, `test (3.12)`, `build`, `Analyze (python)`) must pass before a PR can merge — that's also enforced, not optional. Once it's green, merge the PR (squash or regular merge, your call) rather than merging locally and pushing `main` directly.
+CI (`test (3.10)`, `test (3.12)`, `build`, `Analyze (python)`) must pass before a PR can merge, and that's also enforced, not optional. Once it's green, merge the PR (squash or regular merge, your call) rather than merging locally and pushing `main` directly.
 
 ## Setup
 
@@ -31,24 +31,24 @@ All 75 tests should pass before you open a PR. CI runs this automatically on eve
 
 ## Before opening a PR
 
-- **Add or update tests for anything you change.** This project has been through several rounds of "found a real bug, added a regression test for it" — that pattern is the standard here, not the exception. A behavior change with no test is treated as unverified.
-- **Run the full suite**, not just the file you touched — several modules interact (e.g. changes to `grounding.py`'s `check_substring` affect both `parser.py`'s merge logic and its final grounding check).
+- **Add or update tests for anything you change.** This project has been through several rounds of "found a real bug, added a regression test for it": that pattern is the standard here, not the exception. A behavior change with no test is treated as unverified.
+- **Run the full suite**, not just the file you touched, since several modules interact (e.g. changes to `grounding.py`'s `check_substring` affect both `parser.py`'s merge logic and its final grounding check).
 - **Keep the docs in sync.** If you change a CLI flag, a `Schema`/`Field` option, or the output shape, update the relevant file in `docs/` and/or `README.md` in the same PR. Stale docs have caused real confusion here before (see git history).
-- **Don't break backward compatibility silently.** `DocumentParser.extract()`'s return shape (a dict with `_meta` + one entry per field) is a public contract — the CLI, `ExtractionResult`, and every test depend on it. If a change requires breaking it, say so explicitly in the PR description rather than letting it happen as a side effect.
+- **Don't break backward compatibility silently.** `DocumentParser.extract()`'s return shape (a dict with `_meta` + one entry per field) is a public contract: the CLI, `ExtractionResult`, and every test depend on it. If a change requires breaking it, say so explicitly in the PR description rather than letting it happen as a side effect.
 
 ## Code style
 
-- No comments explaining *what* code does — names should carry that. Comments are for *why*: a non-obvious constraint, a workaround, a decision that would otherwise look arbitrary.
+- No comments explaining *what* code does; names should carry that. Comments are for *why*: a non-obvious constraint, a workaround, a decision that would otherwise look arbitrary.
 - Prefer extending an existing module's pattern over introducing a new one. E.g. a new document format is a new function in `parser.py`'s `INGESTION_HANDLERS`-style registry, not a parallel ingestion system; a new validation rule is a new factory function in `grounding.py`, not a new file.
-- Config knobs belong in `config.py`'s `ExtractionConfig`, not as hardcoded constants scattered through the pipeline — that was a real bug here once (two disconnected page-limit constants caused silent data loss; see `config.py`'s comment on `max_pages`).
+- Config knobs belong in `config.py`'s `ExtractionConfig`, not as hardcoded constants scattered through the pipeline (that was a real bug here once: two disconnected page-limit constants caused silent data loss; see `config.py`'s comment on `max_pages`).
 
 ## Project structure & where to contribute
 
 All library code lives under `src/fastdocparse/` (installed as the `fastdocparse` package); `test_*.py` files under `tests/` import from it as `from fastdocparse import ...` / `from fastdocparse.parser import ...`, exactly as an external user would.
 
-For the module map, the data-flow pipeline, the dependency graph between modules, and a diagram of where common contributions plug in, see **[docs/architecture.md](docs/architecture.md)** — kept as one diagram-based doc rather than duplicated here, so it doesn't drift out of sync with a second copy.
+For the module map, the data-flow pipeline, the dependency graph between modules, and a diagram of where common contributions plug in, see **[docs/architecture.md](docs/architecture.md)**, kept as one diagram-based doc rather than duplicated here, so it doesn't drift out of sync with a second copy.
 
-New public functionality goes through `src/fastdocparse/__init__.py`'s `__all__` — if it's meant to be used from `from fastdocparse import X`, it needs to be re-exported there, not just defined in its own module.
+New public functionality goes through `src/fastdocparse/__init__.py`'s `__all__`. If it's meant to be used from `from fastdocparse import X`, it needs to be re-exported there, not just defined in its own module.
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ Want to contribute? Start with [docs/architecture.md](docs/architecture.md) for 
 
 ## Status
 
-Core extraction, grounding, chunking, both CLI/API paths, and real packaging are implemented and tested (74 tests, `pytest -v`). Published on PyPI as [`fastdocparse`](https://pypi.org/project/fastdocparse/) — `pip install fastdocparse` installs a working `fastdocparse` command and a proper `fastdocparse.*` import namespace, verified end to end with a clean-virtualenv install straight from the real public index. Not yet done: a hosted API — see [document-extractor-spec.md](document-extractor-spec.md) for the roadmap.
+Core extraction, grounding, chunking, both CLI/API paths, and real packaging are implemented and tested (75 tests, `pytest -v`). Published on PyPI as [`fastdocparse`](https://pypi.org/project/fastdocparse/) — `pip install fastdocparse` installs a working `fastdocparse` command and a proper `fastdocparse.*` import namespace, verified end to end with a clean-virtualenv install straight from the real public index. Not yet done: a hosted API — see [document-extractor-spec.md](document-extractor-spec.md) for the roadmap.

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@
 [![CI](https://github.com/pranjalparmar/fastdocparse/actions/workflows/ci.yml/badge.svg)](https://github.com/pranjalparmar/fastdocparse/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Extract structured data from semi-structured documents — invoices, bills, tax forms, resumes, bank statements, shipment manifests — using any OpenAI-compatible LLM (OpenAI, Ollama, vLLM, Groq, etc.), with **per-field grounding and confidence**, not just raw extraction.
+Extract structured data from semi-structured documents (invoices, bills, tax forms, resumes, bank statements, shipment manifests) using any OpenAI-compatible LLM (OpenAI, Ollama, vLLM, Groq, etc.), with **per-field grounding and confidence**, not just raw extraction.
 
 ## Why this, not just another parser
 
 Most extractors give you a value and no way to know if it's real. This one tells you:
 
-- **`grounded`** — the value was found verbatim (or near-verbatim) in the source document text.
-- **`ungrounded`** — the value doesn't appear in the source — likely a hallucination. Flag for human review.
-- **`missing_required`** — a field you marked required came back empty.
-- **`invalid_format`** — the value doesn't match a pattern/enum constraint you declared (e.g. a shipment status outside the allowed list).
-- **`failed_check`** — a custom cross-field rule failed (e.g. line items don't sum to the stated total).
+- **`grounded`**: the value was found verbatim (or near-verbatim) in the source document text.
+- **`ungrounded`**: the value doesn't appear in the source, likely a hallucination. Flag for human review.
+- **`missing_required`**: a field you marked required came back empty.
+- **`invalid_format`**: the value doesn't match a pattern/enum constraint you declared (e.g. a shipment status outside the allowed list).
+- **`failed_check`**: a custom cross-field rule failed (e.g. line items don't sum to the stated total).
 
-No extra LLM call for any of this — it's deterministic, string/rule-based validation against text you already extracted.
+No extra LLM call for any of this: it's deterministic, string/rule-based validation against text you already extracted.
 
-**Where it fits:** semi-structured documents with recurring fields (invoices, bills, tax forms, resumes, statements), and prose documents where *proving* a value came from the source matters (contracts, legal clauses, insurance claims). It is not a vision-LLM pipeline — it works from extracted text (digital PDF text layer, or local OCR for scans/images), which is what keeps it fast, cheap, and usable with small local models. Messy handwritten forms or complex multi-column layouts are a known weaker spot (see [document-extractor-spec.md](document-extractor-spec.md)).
+**Where it fits:** semi-structured documents with recurring fields (invoices, bills, tax forms, resumes, statements), and prose documents where *proving* a value came from the source matters (contracts, legal clauses, insurance claims). It is not a vision-LLM pipeline. It works from extracted text (digital PDF text layer, or local OCR for scans/images), which is what keeps it fast, cheap, and usable with small local models. Messy handwritten forms or complex multi-column layouts are a known weaker spot (see [document-extractor-spec.md](document-extractor-spec.md)).
 
 ## How this compares
 
@@ -27,7 +27,7 @@ No extra LLM call for any of this — it's deterministic, string/rule-based vali
 | **[Sparrow](https://github.com/katanaml/sparrow)** (katanaml) | Vision-LLM first (MLX/vLLM/Ollama/Mistral OCR), multi-service platform, API-first | Layout-aware (sees the page), mature, table templates for complex tables | No GPU required, single `pip install`, Pydantic-schema devex vs. raw JSON-string CLI args |
 | **[LangExtract](https://github.com/google/langextract)** (Google) | Text-first, source-grounding (character-offset mapping), few-shot examples required | Real grounding/traceability, brand trust | Purpose-built for documents (OCR routing) vs. text-in/text-out |
 
-**The honest edge:** *fast, cheap, local-model-friendly extraction for clean-to-moderate documents* — not "better than Sparrow at everything." This has not yet been validated with a real head-to-head benchmark ([tracking issue](https://github.com/pranjalparmar/fastdocparse/issues/19)) — treat it as a design goal, not a proven claim, until that lands.
+**The honest edge:** *fast, cheap, local-model-friendly extraction for clean-to-moderate documents*, not "better than Sparrow at everything." This has not yet been validated with a real head-to-head benchmark ([tracking issue](https://github.com/pranjalparmar/fastdocparse/issues/19)). Treat it as a design goal, not a proven claim, until that lands.
 
 ## Two ways to use it
 
@@ -36,7 +36,7 @@ No extra LLM call for any of this — it's deterministic, string/rule-based vali
 | **CLI** | No coding needed | `fastdocparse extract <file> <schema.json>` |
 | **Python API** | Building it into your own app | `DocumentParser(client).extract(document_bytes, schema)` |
 
-Defining *what* to extract also has two paths — hand-write a JSON/YAML schema file, or describe it in plain English and let the LLM draft the schema for you.
+Defining *what* to extract also has two paths: hand-write a JSON/YAML schema file, or describe it in plain English and let the LLM draft the schema for you.
 
 ## Install
 
@@ -56,9 +56,9 @@ pip install -e ".[dev]"
 
 You also need access to an LLM. Either:
 - An OpenAI API key (`export OPENAI_API_KEY=...` or pass `--api-key`), or
-- A local model via [Ollama](https://ollama.com/) — no API key, no cloud, documents never leave your machine.
+- A local model via [Ollama](https://ollama.com/): no API key, no cloud, documents never leave your machine.
 
-## Quickstart — CLI (no coding)
+## Quickstart: CLI (no coding)
 
 ```bash
 # 1. Extract using one of the bundled example schemas
@@ -91,7 +91,7 @@ fastdocparse schema-from-text \
 fastdocparse extract my_invoice.pdf my_invoice_schema.json
 ```
 
-## Quickstart — Python API
+## Quickstart: Python API
 
 ```python
 from fastdocparse import Schema, Field, LLMClient, DocumentParser
@@ -117,14 +117,14 @@ print(result["invoice_number"])  # {'value': 'INV-9011', 'confidence': 'high', '
 
 ## Full documentation
 
-- [Getting Started](docs/getting-started.md) — step-by-step install, CLI, and API walkthroughs
-- [Schema Guide](docs/schema-guide.md) — every field option (`type`, `required`, `pattern`, `enum`, `sub_fields`, few-shot `examples`), for JSON, YAML, and plain-English authoring
-- [Output & Validation](docs/output-format.md) — the full result shape, what each confidence flag means, and how to write custom cross-check rules
-- [Architecture](docs/architecture.md) — diagrams of the pipeline, the module dependency graph, and where to plug in a contribution
-- [Project spec](document-extractor-spec.md) — architecture, phased roadmap, honest competitive positioning
+- [Getting Started](docs/getting-started.md): step-by-step install, CLI, and API walkthroughs
+- [Schema Guide](docs/schema-guide.md): every field option (`type`, `required`, `pattern`, `enum`, `sub_fields`, few-shot `examples`), for JSON, YAML, and plain-English authoring
+- [Output & Validation](docs/output-format.md): the full result shape, what each confidence flag means, and how to write custom cross-check rules
+- [Architecture](docs/architecture.md): diagrams of the pipeline, the module dependency graph, and where to plug in a contribution
+- [Project spec](document-extractor-spec.md): architecture, phased roadmap, honest competitive positioning
 
 Want to contribute? Start with [docs/architecture.md](docs/architecture.md) for the map, then [CONTRIBUTING.md](CONTRIBUTING.md) for the process.
 
 ## Status
 
-Core extraction, grounding, chunking, both CLI/API paths, and real packaging are implemented and tested (75 tests, `pytest -v`). Published on PyPI as [`fastdocparse`](https://pypi.org/project/fastdocparse/) — `pip install fastdocparse` installs a working `fastdocparse` command and a proper `fastdocparse.*` import namespace, verified end to end with a clean-virtualenv install straight from the real public index. Not yet done: a hosted API — see [document-extractor-spec.md](document-extractor-spec.md) for the roadmap.
+Core extraction, grounding, chunking, both CLI/API paths, and real packaging are implemented and tested (75 tests, `pytest -v`). Published on PyPI as [`fastdocparse`](https://pypi.org/project/fastdocparse/). `pip install fastdocparse` installs a working `fastdocparse` command and a proper `fastdocparse.*` import namespace, verified end to end with a clean-virtualenv install straight from the real public index. Not yet done: a hosted API. See [document-extractor-spec.md](document-extractor-spec.md) for the roadmap.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 How a document turns into structured JSON, how the modules depend on each other, and where to make a change if you're contributing.
 
-## 1. Pipeline — what happens to a document
+## 1. Pipeline: what happens to a document
 
 ```mermaid
 flowchart LR
@@ -20,7 +20,7 @@ flowchart LR
     J --> K["Structured result\n{value, confidence, flags} per field"]
 ```
 
-Each box is one module with one job. A schema with a `list`-type field routes through `structured_mode`, which tags OCR/PDF-extracted lines with column position (`[X:nnn]`) so the LLM can tell columns apart — those tags are stripped again before grounding checks run, since they're layout hints for the LLM, not document content.
+Each box is one module with one job. A schema with a `list`-type field routes through `structured_mode`, which tags OCR/PDF-extracted lines with column position (`[X:nnn]`) so the LLM can tell columns apart. Those tags are stripped again before grounding checks run, since they're layout hints for the LLM, not document content.
 
 ## 2. Module dependency graph
 
@@ -64,7 +64,7 @@ graph TD
     cli --> schema_compiler
 ```
 
-`schema.py` and `config.py` sit at the bottom — nothing depends on them depending back, which is what makes them safe to import from anywhere without creating a cycle. `parser.py` is the only module that touches everything; if you're not sure where a change belongs, this graph tells you whether it's a leaf module (safe, isolated change) or `parser.py` (touches orchestration — run the full suite, not just one test file).
+`schema.py` and `config.py` sit at the bottom: nothing depends on them depending back, which is what makes them safe to import from anywhere without creating a cycle. `parser.py` is the only module that touches everything; if you're not sure where a change belongs, this graph tells you whether it's a leaf module (safe, isolated change) or `parser.py` (touches orchestration, so run the full suite, not just one test file).
 
 ## 3. Where to contribute
 
@@ -85,20 +85,20 @@ flowchart LR
     newprovider --> p3["llm_client.py\nLLMClient._call"]
     clifeature --> p4["cli.py"]
     newauth --> p5["schema.py (Field/Schema)\nschema_compiler.py (NL path)"]
-    docs --> p6["docs/*.md, README.md\n(keep in sync — see rule below)"]
+    docs --> p6["docs/*.md, README.md\n(keep in sync: see rule below)"]
     bugfix --> p7["Reproduce it as a failing test\nfirst (tests/test_severe_edge_cases.py\nis full of examples of this)"]
 ```
 
-Each of these is a real, isolated entry point — none of them require touching `parser.py`'s orchestration logic except the "new document format" case, and even that's additive (register a handler, don't edit `extract()`).
+Each of these is a real, isolated entry point. None of them require touching `parser.py`'s orchestration logic except the "new document format" case, and even that's additive (register a handler, don't edit `extract()`).
 
 ## Why some things are shaped the way they are
 
-A few decisions here look unusual out of context — worth knowing before "fixing" them:
+A few decisions here look unusual out of context, worth knowing before "fixing" them:
 
-- **`ExtractionConfig` is frozen** (`config.py`) — deliberately. A bug here once came from two disconnected page-limit constants; a single, immutable config object closes that class of bug permanently.
-- **`register_ingestion_handler` (instance method) and `register_default_ingestion_handler` (module function) are different names on purpose** — they used to share a name, which made it easy to call the process-wide one by habit when a scoped registration was intended.
-- **Grounding's `numeric=`/`date=` flags are opt-in, not automatic** (`grounding.py`) — an all-digit ID field (invoice number, container number) is a string identity, not a number; `"0100"` must not be treated as equal to `"100"`. Only fields declared `type: "number"/"currency"/"date"` get the tolerant comparison.
-- **The regex-pattern timeout uses `SIGALRM`, not a thread or subprocess** — both were tried and rejected. A thread's `join(timeout)` doesn't work (CPython's `re` engine holds the GIL during backtracking, so the timeout never fires). A subprocess works in isolation but crashed the whole process on exit here, because this app loads a native ML runtime (RapidOCR/onnxruntime) at OCR-init time and the two didn't coexist safely. See `grounding.py`'s `_regex_matches_with_timeout` docstring for the full story.
-- **`__init__.py` doesn't lazy-load its re-exports beyond `ocr_engine`'s OCR engine itself** — `import fastdocparse` costs about 0.6s, mostly from the `openai` SDK's own import graph. This was measured, not guessed (see `ocr_engine.py`'s `HAS_RAPID_OCR` — that one *is* lazy, via `importlib.util.find_spec`, because it used to add another 0.8s on its own).
+- **`ExtractionConfig` is frozen** (`config.py`), deliberately. A bug here once came from two disconnected page-limit constants; a single, immutable config object closes that class of bug permanently.
+- **`register_ingestion_handler` (instance method) and `register_default_ingestion_handler` (module function) are different names on purpose.** They used to share a name, which made it easy to call the process-wide one by habit when a scoped registration was intended.
+- **Grounding's `numeric=`/`date=` flags are opt-in, not automatic** (`grounding.py`). An all-digit ID field (invoice number, container number) is a string identity, not a number; `"0100"` must not be treated as equal to `"100"`. Only fields declared `type: "number"/"currency"/"date"` get the tolerant comparison.
+- **The regex-pattern timeout uses `SIGALRM`, not a thread or subprocess.** Both were tried and rejected. A thread's `join(timeout)` doesn't work (CPython's `re` engine holds the GIL during backtracking, so the timeout never fires). A subprocess works in isolation but crashed the whole process on exit here, because this app loads a native ML runtime (RapidOCR/onnxruntime) at OCR-init time and the two didn't coexist safely. See `grounding.py`'s `_regex_matches_with_timeout` docstring for the full story.
+- **`__init__.py` doesn't lazy-load its re-exports beyond `ocr_engine`'s OCR engine itself.** `import fastdocparse` costs about 0.6s, mostly from the `openai` SDK's own import graph. This was measured, not guessed (see `ocr_engine.py`'s `HAS_RAPID_OCR`, which *is* lazy, via `importlib.util.find_spec`, because it used to add another 0.8s on its own).
 
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the actual PR process, and [Output & Validation](output-format.md) for what each grounding flag means from a user's perspective.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,6 @@ graph TD
     schema_compiler --> schema
     schema_compiler --> llm_client
     schema_compiler --> json_repair
-    result --> schema
 
     parser --> schema
     parser --> config

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,27 +16,27 @@ pip install -e .
 
 You need one of:
 
-- **OpenAI** — an API key from https://platform.openai.com/. No local install.
-- **A local model via Ollama** (recommended if your documents are sensitive — nothing leaves your machine):
+- **OpenAI**: an API key from https://platform.openai.com/. No local install.
+- **A local model via Ollama** (recommended if your documents are sensitive, since nothing leaves your machine):
   1. Install Ollama: https://ollama.com/
   2. Pull a model: `ollama run llama3.2` (or any model that supports JSON-mode-style output)
   3. Ollama serves an OpenAI-compatible API at `http://localhost:11434/v1` automatically.
-- **Any other OpenAI-compatible endpoint** (vLLM, Groq, etc.) — just its base URL, API key, and model name.
+- **Any other OpenAI-compatible endpoint** (vLLM, Groq, etc.): just its base URL, API key, and model name.
 
-Nothing in this project is tied to OpenAI specifically — swapping `--base-url`/`--model` is the only change needed to switch providers.
+Nothing in this project is tied to OpenAI specifically. Swapping `--base-url`/`--model` is the only change needed to switch providers.
 
 ---
 
-## Path A — CLI (no coding)
+## Path A: CLI (no coding)
 
 ### A.1 Pick or write a schema
 
 A schema is a JSON (or YAML) file listing the fields you want extracted. Two are bundled as starting points:
 
-- [`src/fastdocparse/schemas/invoice.json`](../src/fastdocparse/schemas/invoice.json) — invoice number, dates, parties, line items, few-shot examples included.
-- [`src/fastdocparse/schemas/shipment_manifest.json`](../src/fastdocparse/schemas/shipment_manifest.json) — bill of lading, container number, HS code, shipment status (with `required`/`pattern`/`enum` constraints).
+- [`src/fastdocparse/schemas/invoice.json`](../src/fastdocparse/schemas/invoice.json): invoice number, dates, parties, line items, few-shot examples included.
+- [`src/fastdocparse/schemas/shipment_manifest.json`](../src/fastdocparse/schemas/shipment_manifest.json): bill of lading, container number, HS code, shipment status (with `required`/`pattern`/`enum` constraints).
 
-Copy one and edit field names/descriptions for your document type, or write your own from scratch — see the [Schema Guide](schema-guide.md) for every option.
+Copy one and edit field names/descriptions for your document type, or write your own from scratch. See the [Schema Guide](schema-guide.md) for every option.
 
 **Don't want to write JSON at all?** Describe what you want in plain English:
 
@@ -46,7 +46,7 @@ fastdocparse schema-from-text \
   --output schemas/my_invoice.json
 ```
 
-This makes one LLM call, writes `schemas/my_invoice.json`, and prints a confirmation. **Open the file and check it before using it for real extraction** — the LLM is guessing field names/types from your wording, and a wrong guess here will affect every document you run against this schema afterward.
+This makes one LLM call, writes `schemas/my_invoice.json`, and prints a confirmation. **Open the file and check it before using it for real extraction.** The LLM is guessing field names/types from your wording, and a wrong guess here will affect every document you run against this schema afterward.
 
 ### A.2 Run extraction
 
@@ -82,7 +82,7 @@ See [Output & Validation](output-format.md) for the full shape and what each fla
 
 ---
 
-## Path B — Python API
+## Path B: Python API
 
 ### B.1 Define a schema in code
 
@@ -181,12 +181,12 @@ result = parser.extract(docx_bytes, schema, kind="docx")
 
 `DocumentParser.register_ingestion_handler()` (instance method) scopes the handler to
 that one parser. There's also a module-level `parser.register_default_ingestion_handler()`
-that changes what *new* `DocumentParser()` instances get by default — deliberately a
+that changes what *new* `DocumentParser()` instances get by default. It's deliberately a
 different name, so it's never confused with the instance-scoped version at a call site.
 
 **Using this from the CLI:** a fresh CLI process only knows the built-in `pdf`/`image`
 handlers, so a custom `kind` needs to be registered before the CLI dispatches. Set
-`FASTDOCPARSE_PLUGINS` to a comma-separated list of importable module names — each one is
+`FASTDOCPARSE_PLUGINS` to a comma-separated list of importable module names. Each one is
 imported at CLI startup, so put your `register_default_ingestion_handler(...)` call at
 module level in that file:
 
@@ -195,7 +195,7 @@ FASTDOCPARSE_PLUGINS=my_project.docx_plugin fastdocparse extract contract.docx s
 ```
 
 **Security note:** this imports and runs whatever Python is in the module(s) you name,
-with no sandboxing — the same trust model as `PYTHONSTARTUP` or `DJANGO_SETTINGS_MODULE`.
+with no sandboxing, the same trust model as `PYTHONSTARTUP` or `DJANGO_SETTINGS_MODULE`.
 That's fine for pointing it at your own plugin on your own machine. Never let
 `FASTDOCPARSE_PLUGINS` be set from an untrusted source (e.g. a parameter in a hosted
 service built on top of this CLI).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,8 +5,8 @@ Step-by-step for both the no-code (CLI) path and the developer (Python API) path
 ## 1. Install
 
 ```bash
-git clone <this repo>
-cd document-extractor
+git clone https://github.com/pranjalparmar/fastdocparse
+cd fastdocparse
 python -m venv venv
 source venv/bin/activate        # Windows: venv\Scripts\activate
 pip install -e .

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -23,7 +23,7 @@
 }
 ```
 
-Every field declared in the schema appears in the output, even if nothing was found — missing data comes back as `"value": null`, never a dropped key.
+Every field declared in the schema appears in the output, even if nothing was found. Missing data comes back as `"value": null`, never a dropped key.
 
 ### `_meta`
 
@@ -40,25 +40,25 @@ Every field declared in the schema appears in the output, even if nothing was fo
 | `confidence` | `"high"` if grounded in the source text, `"low"` otherwise. |
 | `flags` | Zero or more of the flags below. |
 
-## Flags — what each one means and what to do about it
+## Flags: what each one means and what to do about it
 
 | Flag | Meaning | Suggested action |
 |---|---|---|
 | `grounded` | The value was found verbatim (or fuzzy-matched, including numeric-format differences like `1,234.50` vs `1234.5`) in the extracted source text. | Trust it. |
-| `ungrounded` | A non-null value was returned, but it doesn't appear anywhere in the source text — possible hallucination. | Route to human review before using. |
-| `missing_required` | The field is marked `required: true` in the schema, but came back `null`. | Treat as a failed extraction — don't silently proceed. |
-| `invalid_format` | The value violates a `pattern` or `enum` constraint declared on the field. | Review — either the extraction is wrong, or the constraint needs loosening. |
-| `failed_check` | A custom cross-check rule (passed via `rules=[...]`) flagged this field. | Depends on the rule — typically a cross-field consistency problem (e.g. totals don't sum). |
+| `ungrounded` | A non-null value was returned, but it doesn't appear anywhere in the source text: possible hallucination. | Route to human review before using. |
+| `missing_required` | The field is marked `required: true` in the schema, but came back `null`. | Treat as a failed extraction; don't silently proceed. |
+| `invalid_format` | The value violates a `pattern` or `enum` constraint declared on the field. | Review. Either the extraction is wrong, or the constraint needs loosening. |
+| `failed_check` | A custom cross-check rule (passed via `rules=[...]`) flagged this field. | Depends on the rule, typically a cross-field consistency problem (e.g. totals don't sum). |
 
 A field can carry multiple flags at once, e.g. `["ungrounded", "invalid_format"]`.
 
-**Grounding and constraint checks cost zero extra LLM calls** — they're deterministic string/regex checks against text already extracted from the document.
+**Grounding and constraint checks cost zero extra LLM calls.** They're deterministic string/regex checks against text already extracted from the document.
 
 ## Built-in cross-check rules
 
-Two ready-made rules ship with `fastdocparse` — no need to write your own for these common cases:
+Two ready-made rules ship with `fastdocparse`, so there's no need to write your own for these common cases:
 
-### `numeric_sum_rule` — flag when a total doesn't match a list's sum
+### `numeric_sum_rule`: flag when a total doesn't match a list's sum
 
 ```python
 from fastdocparse import numeric_sum_rule
@@ -69,7 +69,7 @@ result = parser.extract(document_bytes, schema, rules=[rule])
 
 Flags both `total_price` and `line_items` with `failed_check` if `sum(item["unit_price"] for item in line_items)` doesn't match `total_price` within `tolerance`.
 
-### `date_parseable_rule` — flag an unparseable date
+### `date_parseable_rule`: flag an unparseable date
 
 ```python
 from fastdocparse import date_parseable_rule
@@ -96,6 +96,6 @@ def stock_check(extracted: dict) -> list[Issue] | None:
 result = parser.extract(document_bytes, schema, rules=[stock_check])
 ```
 
-Return `None` (or an empty list) when there's no issue. Any exception a rule raises is caught and logged (not silently swallowed) — it won't crash extraction, but check your logs if a rule you expected to fire isn't showing up.
+Return `None` (or an empty list) when there's no issue. Any exception a rule raises is caught and logged (not silently swallowed). It won't crash extraction, but check your logs if a rule you expected to fire isn't showing up.
 
 Rules run against the fully merged result (after multi-chunk merging), so they can safely compare fields that might live in different chunks of a long document (e.g. a total on page 1 vs. line items on page 8).

--- a/docs/schema-guide.md
+++ b/docs/schema-guide.md
@@ -1,6 +1,6 @@
 # Schema Guide
 
-A schema declares *what* to extract. It works identically whether you write it as JSON, YAML, or Python — same fields, same meaning, same validation.
+A schema declares *what* to extract. It works identically whether you write it as JSON, YAML, or Python: same fields, same meaning, same validation.
 
 ## Minimal schema
 
@@ -19,13 +19,13 @@ A schema declares *what* to extract. It works identically whether you write it a
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
-| `name` | string | — (required) | Output key. Use `snake_case`, no spaces. |
-| `description` | string | — (required) | Tells the LLM what to look for. Be specific — this is the main lever for extraction accuracy. |
+| `name` | string | n/a (required) | Output key. Use `snake_case`, no spaces. |
+| `description` | string | n/a (required) | Tells the LLM what to look for. Be specific: this is the main lever for extraction accuracy. |
 | `type` | `"text"` \| `"number"` \| `"date"` \| `"currency"` \| `"list"` | `"text"` | `"list"` triggers structured (layout-aware) extraction mode automatically. Other types are descriptive hints for the LLM, not enforced coercion. |
 | `required` | bool | `false` | If `true` and the field comes back empty, the result is flagged `missing_required`. |
 | `pattern` | string (regex) or `null` | `null` | If the extracted value doesn't fully match this regex, flagged `invalid_format`. Use for structured codes: HS codes, container numbers, SSNs, invoice number formats. |
 | `enum` | list of strings or `null` | `null` | If the value isn't one of these, flagged `invalid_format`. Use for closed vocabularies: shipment status, currency codes, filing status. |
-| `sub_fields` | list of `Field` or `null` | `null` | Only for `type: "list"` — describes each item's columns (e.g. a line-items table). |
+| `sub_fields` | list of `Field` or `null` | `null` | Only for `type: "list"`: describes each item's columns (e.g. a line-items table). |
 
 ## Example: a table field (`sub_fields`)
 
@@ -85,7 +85,7 @@ Schemas can include example (document snippet → expected output) pairs. Useful
 }
 ```
 
-Each example is a 2-element array: `[document_snippet_string, expected_output_object]`. The expected output must cover the fields you want to demonstrate — it doesn't need every field in the schema.
+Each example is a 2-element array: `[document_snippet_string, expected_output_object]`. The expected output must cover the fields you want to demonstrate; it doesn't need every field in the schema.
 
 See [`src/fastdocparse/schemas/invoice.json`](../src/fastdocparse/schemas/invoice.json) for a complete example with a few-shot pair.
 
@@ -97,7 +97,7 @@ from fastdocparse import Schema
 schema = Schema.from_file("src/fastdocparse/schemas/invoice.json")   # or .yaml/.yml
 ```
 
-**CLI:** pass the path directly — `fastdocparse extract doc.pdf src/fastdocparse/schemas/invoice.json`.
+**CLI:** pass the path directly: `fastdocparse extract doc.pdf src/fastdocparse/schemas/invoice.json`.
 
 ## Writing a schema in Python instead of JSON
 
@@ -115,7 +115,7 @@ schema = Schema(
 )
 ```
 
-Use this path when you need something a static schema file can't express — e.g. building the field list dynamically at runtime.
+Use this path when you need something a static schema file can't express, e.g. building the field list dynamically at runtime.
 
 ## Generating a schema from plain English
 
@@ -127,7 +127,7 @@ fastdocparse schema-from-text \
   --output schemas/my_manifest.json
 ```
 
-This sends your description to the LLM once and writes a schema file in the exact format above. **Always open and review the generated file before trusting it for real extraction** — the LLM is inferring field names, types, and constraints from your wording, and mistakes here are silent (a wrong `pattern` or missing `required` won't error, it'll just quietly under- or over-flag every document you later run against this schema).
+This sends your description to the LLM once and writes a schema file in the exact format above. **Always open and review the generated file before trusting it for real extraction.** The LLM is inferring field names, types, and constraints from your wording, and mistakes here are silent (a wrong `pattern` or missing `required` won't error, it'll just quietly under- or over-flag every document you later run against this schema).
 
 Good descriptions to feed it:
 - List the specific fields you want, don't just name the document type ("extract the fields" is too vague; "extract invoice number, total price, and vendor name" works).

--- a/document-extractor-spec.md
+++ b/document-extractor-spec.md
@@ -1,14 +1,14 @@
-# Dynamic Document Extractor — Project Specification
+# Dynamic Document Extractor: Project Specification
 
-**Status:** Published on PyPI as `fastdocparse` — Phases 1–5 complete, Phase 6 (packaging/publish) done; see [README.md](README.md) for current state. The rest of this document is preserved as the original planning record; sections below describing earlier phases as "not started" are historical, not current status.
-**Base name:** `fastdocparse` — see [Naming](#naming) for how this was decided (`docextract`, the original top pick, was blocked by PyPI's project-name-similarity rule against the pre-existing `doc-extract`)
+**Status:** Published on PyPI as `fastdocparse`: Phases 1–5 complete, Phase 6 (packaging/publish) done; see [README.md](README.md) for current state. The rest of this document is preserved as the original planning record; sections below describing earlier phases as "not started" are historical, not current status.
+**Base name:** `fastdocparse`: see [Naming](#naming) for how this was decided (`docextract`, the original top pick, was blocked by PyPI's project-name-similarity rule against the pre-existing `doc-extract`)
 **Origin:** Generalization of `invoice-details-extractor` (github.com/pranjalparmar/invoice-details-extractor) into a schema-driven, model-agnostic document extraction library.
 
 ---
 
 ## 1. Idea, in one paragraph
 
-A Python library that takes a PDF, PNG, or JPG, a user-defined schema describing what to extract, and a pointer to any CoT-capable LLM (OpenAI, Ollama, vLLM, any OpenAI-compatible endpoint) — and returns validated structured JSON. It separates fast local document ingestion (digital-PDF text extraction or local OCR) from a single reasoning pass, avoiding the latency and GPU cost of vision-LLM-first pipelines, while remaining honest about the accuracy trade-offs that separation creates.
+A Python library that takes a PDF, PNG, or JPG, a user-defined schema describing what to extract, and a pointer to any CoT-capable LLM (OpenAI, Ollama, vLLM, any OpenAI-compatible endpoint), and returns validated structured JSON. It separates fast local document ingestion (digital-PDF text extraction or local OCR) from a single reasoning pass, avoiding the latency and GPU cost of vision-LLM-first pipelines, while remaining honest about the accuracy trade-offs that separation creates.
 
 ## 2. Why this, and the honest competitive position
 
@@ -16,16 +16,16 @@ A Python library that takes a PDF, PNG, or JPG, a user-defined schema describing
 |---|---|---|---|---|
 | **Sparrow** (katanaml) | 5.2k stars, 518 forks, commercial backing | Vision-LLM first (MLX/vLLM/Ollama/Mistral OCR), multi-service platform, API-first | Layout-aware (sees the page), mature, table templates for complex tables | No GPU required, single `pip install`, Pydantic-schema devex vs. raw JSON-string CLI args |
 | **LangExtract** (Google) | Google-backed, press coverage | Text-first, source-grounding (character-offset mapping), few-shot examples required | Real grounding/traceability, brand trust | Purpose-built for documents (OCR routing) vs. text-in/text-out |
-| ocrcontext, indoxminer, DELM, others | Small/low adoption | Various | — | Little competitive pressure from these |
+| ocrcontext, indoxminer, DELM, others | Small/low adoption | Various | n/a | Little competitive pressure from these |
 
-**The honest edge:** *fast, cheap, local-model-friendly extraction for clean-to-moderate documents* — not "better than Sparrow at everything." This must be validated with real benchmarks before it's claimed publicly (see Phase 6).
+**The honest edge:** *fast, cheap, local-model-friendly extraction for clean-to-moderate documents*, not "better than Sparrow at everything." This must be validated with real benchmarks before it's claimed publicly (see Phase 6).
 
 **Known weaknesses in the current (invoice-only) approach that this spec exists to fix, in priority order:**
-1. No grounding — a non-empty field is treated as "confidence: 95," which is not a real confidence signal.
-2. Layout is discarded — bounding boxes get flattened into linear text before the LLM sees them, which breaks on multi-column layouts and complex tables.
-3. No self-correction — one LLM call, one parse attempt, no cross-checks (e.g. line items vs. stated total).
+1. No grounding: a non-empty field is treated as "confidence: 95," which is not a real confidence signal.
+2. Layout is discarded: bounding boxes get flattened into linear text before the LLM sees them, which breaks on multi-column layouts and complex tables.
+3. No self-correction: one LLM call, one parse attempt, no cross-checks (e.g. line items vs. stated total).
 4. Prompt quality is currently hand-tuned per document type (invoices); generalizing to arbitrary schemas risks losing that tuning unless few-shot examples are supported.
-5. No chunking — hardcoded `max_pages=3`, unsuitable for statements/contracts.
+5. No chunking: hardcoded `max_pages=3`, unsuitable for statements/contracts.
 
 ---
 
@@ -63,27 +63,27 @@ Structured output (JSON) + per-field confidence/flags
 ```
 
 Core modules (extending the existing repo structure):
-- `pdf_utils.py` — unchanged, digital PDF text/layout extraction
-- `ocr_engine.py` — unchanged, local OCR fallback
-- `schema.py` — **new**: Pydantic-based schema definition, field descriptions, optional few-shot examples
-- `prompt_compiler.py` — **new**: deterministic template that turns a schema (+ examples) into a CoT prompt
-- `llm_client.py` — **new**: thin adapter over any OpenAI-compatible endpoint
-- `parser.py` — **new**: orchestrates the pipeline, exposes `DocumentParser`
-- `grounding.py` — **new** (Phase 2): substring/fuzzy match of extracted values against source text, cross-field checks
-- `cli.py` — **new** (Phase 6): thin CLI wrapper over the library
+- `pdf_utils.py`: unchanged, digital PDF text/layout extraction
+- `ocr_engine.py`: unchanged, local OCR fallback
+- `schema.py`: **new**: Pydantic-based schema definition, field descriptions, optional few-shot examples
+- `prompt_compiler.py`: **new**: deterministic template that turns a schema (+ examples) into a CoT prompt
+- `llm_client.py`: **new**: thin adapter over any OpenAI-compatible endpoint
+- `parser.py`: **new**: orchestrates the pipeline, exposes `DocumentParser`
+- `grounding.py`: **new** (Phase 2): substring/fuzzy match of extracted values against source text, cross-field checks
+- `cli.py`: **new** (Phase 6): thin CLI wrapper over the library
 
 ---
 
 ## 4. Phases
 
-### Phase 1 — Generalized core (workable prototype)
+### Phase 1: Generalized core (workable prototype)
 
 **Goal:** Same capability as the current invoice extractor, but schema and model are runtime parameters instead of hardcoded.
 
 **Technical tasks:**
 - [ ] Define `Schema` / `Field` classes (Pydantic-based): `name`, `type`, `description`, `required`
-- [ ] Build `prompt_compiler.compile(schema) -> str` — deterministic template, no LLM call
-- [ ] Build `llm_client.LLMClient(base_url, api_key, model)` — OpenAI-compatible wrapper; must work against at least OpenAI, a local Ollama instance, and one other OpenAI-compatible endpoint
+- [ ] Build `prompt_compiler.compile(schema) -> str`: deterministic template, no LLM call
+- [ ] Build `llm_client.LLMClient(base_url, api_key, model)`: OpenAI-compatible wrapper; must work against at least OpenAI, a local Ollama instance, and one other OpenAI-compatible endpoint
 - [ ] Build `DocumentParser.extract(document, schema, model) -> dict` orchestrating: route → compile prompt → call LLM → parse/repair (reuse existing `_parse_json_from_llm` logic)
 - [ ] Preserve existing routing logic from `pdf_utils.py` / `ocr_engine.py` unchanged
 - [ ] Remove hardcoded `FIELD_SCHEMA` / `FAST_COT_PROMPT` / `GLM_TEXT_MODEL` / `get_fhgenie_client()` dependencies from the core path (invoice-specific prompt can remain as a *pre-built example schema*, not the only path)
@@ -91,27 +91,27 @@ Core modules (extending the existing repo structure):
 **Required system behavior:**
 - Given a schema with N fields and a document, the system returns a dict with exactly those N keys (missing data → `null`, not omitted).
 - Swapping `model=` between two different OpenAI-compatible endpoints must require no code change, only the parameter.
-- A digital PDF must route through PyMuPDF; a PNG/JPG or scanned PDF must route through OCR — this must be automatic, not user-specified.
+- A digital PDF must route through PyMuPDF; a PNG/JPG or scanned PDF must route through OCR. This must be automatic, not user-specified.
 - If the LLM response isn't valid JSON on first parse, the existing repair fallback (strip `<think>` tags, extract fenced block, brace-match) must still recover it.
 
 **Test cases:**
-- [ ] TC1.1 — Extract a known-good digital invoice PDF with the original invoice schema; output matches the current extractor's output field-for-field.
-- [ ] TC1.2 — Extract the same document with a *different*, arbitrary schema (e.g. 3 unrelated fields); output has exactly those 3 keys.
-- [ ] TC1.3 — Extract a scanned/image receipt (JPG) with a receipt-specific schema; confirm OCR path is used (assert via log/route flag) and output is non-empty.
-- [ ] TC1.4 — Point `model=` at two different endpoints (e.g. OpenAI vs. local Ollama model) for the same document/schema; both return valid JSON matching the schema shape (values may differ).
-- [ ] TC1.5 — Feed a deliberately malformed LLM response (simulate via a stub client that returns text with a `<think>` block and extra prose) through the parser; confirm correct JSON is still recovered.
-- [ ] TC1.6 — Feed a document missing a requested field; confirm the field comes back `null`, not omitted or hallucinated with a placeholder.
-- [ ] TC1.7 — Benchmark: run TC1.1 five times, log latency; confirm it's within the same order of magnitude as the original invoice extractor (no regression from the abstraction layers).
+- [ ] TC1.1: Extract a known-good digital invoice PDF with the original invoice schema; output matches the current extractor's output field-for-field.
+- [ ] TC1.2: Extract the same document with a *different*, arbitrary schema (e.g. 3 unrelated fields); output has exactly those 3 keys.
+- [ ] TC1.3: Extract a scanned/image receipt (JPG) with a receipt-specific schema; confirm OCR path is used (assert via log/route flag) and output is non-empty.
+- [ ] TC1.4: Point `model=` at two different endpoints (e.g. OpenAI vs. local Ollama model) for the same document/schema; both return valid JSON matching the schema shape (values may differ).
+- [ ] TC1.5: Feed a deliberately malformed LLM response (simulate via a stub client that returns text with a `<think>` block and extra prose) through the parser; confirm correct JSON is still recovered.
+- [ ] TC1.6: Feed a document missing a requested field; confirm the field comes back `null`, not omitted or hallucinated with a placeholder.
+- [ ] TC1.7: Benchmark: run TC1.1 five times, log latency; confirm it's within the same order of magnitude as the original invoice extractor (no regression from the abstraction layers).
 
 ---
 
-### Phase 2 — Grounding & sanity checks
+### Phase 2: Grounding & sanity checks
 
-**Goal:** Replace the placeholder "confidence: 95 if non-empty" with a real, cheap signal — no extra LLM call.
+**Goal:** Replace the placeholder "confidence: 95 if non-empty" with a real, cheap signal: no extra LLM call.
 
 **Technical tasks:**
-- [ ] Build `grounding.check_substring(value, source_text) -> bool` — fuzzy match extracted value against the raw OCR/PyMuPDF text already available
-- [ ] Build `grounding.cross_check(schema, extracted) -> list[Issue]` — pluggable rule hooks (e.g. "line items sum to total", "date is parseable")
+- [ ] Build `grounding.check_substring(value, source_text) -> bool`: fuzzy match extracted value against the raw OCR/PyMuPDF text already available
+- [ ] Build `grounding.cross_check(schema, extracted) -> list[Issue]`: pluggable rule hooks (e.g. "line items sum to total", "date is parseable")
 - [ ] Attach a `confidence` and `flags: list[str]` per field to the output, derived from the above (not a fixed constant)
 - [ ] Document the confidence semantics clearly (e.g. "grounded" = found in source text; "ungrounded" = not found, possible hallucination; "failed_check" = cross-check rule failed)
 
@@ -121,15 +121,15 @@ Core modules (extending the existing repo structure):
 - Grounding checks must not require any additional model call (deterministic/string-based only).
 
 **Test cases:**
-- [ ] TC2.1 — Extract a field whose value appears verbatim in the source text; confirm it's marked grounded/high-confidence.
-- [ ] TC2.2 — Use a stub LLM client that returns a plausible but fabricated value not present in the source text; confirm it's flagged as ungrounded.
-- [ ] TC2.3 — Extract line items that sum to a different total than the stated total field; confirm both are flagged by the cross-check.
-- [ ] TC2.4 — Extract a date field with an unparseable value; confirm it's flagged.
-- [ ] TC2.5 — Confirm Phase 2 adds no additional LLM API calls (mock/count calls in a test harness; count must equal Phase 1's count).
+- [ ] TC2.1: Extract a field whose value appears verbatim in the source text; confirm it's marked grounded/high-confidence.
+- [ ] TC2.2: Use a stub LLM client that returns a plausible but fabricated value not present in the source text; confirm it's flagged as ungrounded.
+- [ ] TC2.3: Extract line items that sum to a different total than the stated total field; confirm both are flagged by the cross-check.
+- [ ] TC2.4: Extract a date field with an unparseable value; confirm it's flagged.
+- [ ] TC2.5: Confirm Phase 2 adds no additional LLM API calls (mock/count calls in a test harness; count must equal Phase 1's count).
 
 ---
 
-### Phase 3 — Few-shot schema definition
+### Phase 3: Few-shot schema definition
 
 **Goal:** Recover per-document-type accuracy without hand-tuning the core prompt template.
 
@@ -143,13 +143,13 @@ Core modules (extending the existing repo structure):
 - A schema with 1–3 examples must produce measurably better accuracy than 0 examples on a held-out test document of the same type (see test cases).
 
 **Test cases:**
-- [ ] TC3.1 — Run the same non-invoice schema (e.g. a receipt schema) with 0 examples vs. 2 examples against a held-out document; log accuracy (field-level exact match against a manually labeled ground truth) for both; confirm the with-examples run is equal or better.
-- [ ] TC3.2 — Confirm the invoice schema, rebuilt with few-shot examples instead of the old hand-written CoT prompt, matches or beats the original hand-tuned extractor's accuracy on the same test set (this determines whether the generalization "worked").
-- [ ] TC3.3 — Confirm a schema with malformed/mismatched examples (example dict doesn't match schema fields) raises a clear validation error at schema-definition time, not silently at extraction time.
+- [ ] TC3.1: Run the same non-invoice schema (e.g. a receipt schema) with 0 examples vs. 2 examples against a held-out document; log accuracy (field-level exact match against a manually labeled ground truth) for both; confirm the with-examples run is equal or better.
+- [ ] TC3.2: Confirm the invoice schema, rebuilt with few-shot examples instead of the old hand-written CoT prompt, matches or beats the original hand-tuned extractor's accuracy on the same test set (this determines whether the generalization "worked").
+- [ ] TC3.3: Confirm a schema with malformed/mismatched examples (example dict doesn't match schema fields) raises a clear validation error at schema-definition time, not silently at extraction time.
 
 ---
 
-### Phase 4 — Layout-awareness for tables
+### Phase 4: Layout-awareness for tables
 
 **Goal:** Stop discarding layout before the LLM sees the document; specifically fix multi-column and table extraction.
 
@@ -159,17 +159,17 @@ Core modules (extending the existing repo structure):
 - [ ] Evaluate whether a lightweight table-reconstruction step (e.g. row/column clustering from bounding boxes) is needed before this is reliable, or whether prompt-level hints suffice
 
 **Required system behavior:**
-- A schema with a `list[dict]` (table-like) field must, in structured mode, produce row-consistent output on a genuinely multi-column source document — not just single-column-friendly ones.
+- A schema with a `list[dict]` (table-like) field must, in structured mode, produce row-consistent output on a genuinely multi-column source document, not just single-column-friendly ones.
 - Non-table schemas must be unaffected (no regression to Phase 1–3 behavior/latency for simple field extraction).
 
 **Test cases:**
-- [ ] TC4.1 — Extract a table field from a known multi-column layout (e.g. a two-column bank statement or bonds table); compare row/column fidelity against flat-text mode from Phase 1 on the same document.
-- [ ] TC4.2 — Confirm a non-table schema run in Phase 4 code has no measurable latency regression vs. Phase 1.
-- [ ] TC4.3 — Stress test: a document with a genuinely complex table (merged cells, multi-row headers); document known failure modes even if not fully solved — this phase's exit criterion is "measurably better than flat-text, honestly documented gaps," not perfection.
+- [ ] TC4.1: Extract a table field from a known multi-column layout (e.g. a two-column bank statement or bonds table); compare row/column fidelity against flat-text mode from Phase 1 on the same document.
+- [ ] TC4.2: Confirm a non-table schema run in Phase 4 code has no measurable latency regression vs. Phase 1.
+- [ ] TC4.3: Stress test: a document with a genuinely complex table (merged cells, multi-row headers); document known failure modes even if not fully solved: this phase's exit criterion is "measurably better than flat-text, honestly documented gaps," not perfection.
 
 ---
 
-### Phase 5 — Multi-page & chunking
+### Phase 5: Multi-page & chunking
 
 **Goal:** Remove the hardcoded page cap; support longer documents.
 
@@ -183,20 +183,20 @@ Core modules (extending the existing repo structure):
 - Schema fields that are lists (e.g. transactions) must accumulate correctly across chunks, not just return the last chunk's data.
 
 **Test cases:**
-- [ ] TC5.1 — Extract a list-type field from a synthetic 10-page document where relevant rows are spread across pages 1, 5, and 9; confirm all rows are present in the merged output.
-- [ ] TC5.2 — Extract a single-value field from page 8 of a 10-page document; confirm it's found (not missed due to chunk boundary).
-- [ ] TC5.3 — Feed a document exceeding any configured hard limit; confirm the system returns a clear truncation flag rather than silently dropping data.
+- [ ] TC5.1: Extract a list-type field from a synthetic 10-page document where relevant rows are spread across pages 1, 5, and 9; confirm all rows are present in the merged output.
+- [ ] TC5.2: Extract a single-value field from page 8 of a 10-page document; confirm it's found (not missed due to chunk boundary).
+- [ ] TC5.3: Feed a document exceeding any configured hard limit; confirm the system returns a clear truncation flag rather than silently dropping data.
 
 ---
 
-### Phase 6 — Benchmark, package, publish
+### Phase 6: Benchmark, package, publish
 
 **Goal:** Prove the speed/cost claim, ship it properly.
 
 **Technical tasks:**
 - [ ] Finalize package name (see [Naming](#naming)); register on PyPI
 - [ ] Build `pyproject.toml`, package structure, `cli.py` as a thin wrapper over the library
-- [ ] Run a head-to-head benchmark against Sparrow's `sparrow-parse` pipeline on a shared test set (10–20 mixed documents: invoices, receipts, forms) — log latency, cost (if applicable), and field-level accuracy for both
+- [ ] Run a head-to-head benchmark against Sparrow's `sparrow-parse` pipeline on a shared test set (10–20 mixed documents: invoices, receipts, forms): log latency, cost (if applicable), and field-level accuracy for both
 - [ ] Write README leading with the comparison table and honest scope ("fast/local option for clean-to-moderate documents," not "better than Sparrow at everything")
 - [ ] Publish to PyPI; prepare launch posts for r/LocalLLaMA, r/Python, Show HN
 
@@ -204,9 +204,9 @@ Core modules (extending the existing repo structure):
 - `pip install <package>` then a 3-line script must successfully extract a schema from a sample document with zero additional setup beyond an API key or local Ollama install.
 
 **Test cases:**
-- [ ] TC6.1 — Fresh virtual environment, `pip install` from PyPI (not local dev install), run the README quickstart verbatim; confirm it works with no undocumented steps.
-- [ ] TC6.2 — Run the benchmark suite against both this library and Sparrow on the same 10–20 documents; confirm numbers are reproducible on a second run (within reasonable variance) before publishing them.
-- [ ] TC6.3 — CLI smoke test: `<cli> --file invoice.pdf --schema schema.json --model ollama/llama3` produces valid JSON output to stdout/file.
+- [ ] TC6.1: Fresh virtual environment, `pip install` from PyPI (not local dev install), run the README quickstart verbatim; confirm it works with no undocumented steps.
+- [ ] TC6.2: Run the benchmark suite against both this library and Sparrow on the same 10–20 documents; confirm numbers are reproducible on a second run (within reasonable variance) before publishing them.
+- [ ] TC6.3: CLI smoke test: `<cli> --file invoice.pdf --schema schema.json --model ollama/llama3` produces valid JSON output to stdout/file.
 
 ---
 
@@ -221,7 +221,7 @@ Core modules (extending the existing repo structure):
 | `fastdocparse` | ✅ Available |
 | `doc-fastparse` | ✅ Available |
 
-Decision: `docextract` was the original pick and was fully built under that name (import path, CLI command, GitHub repo) — but PyPI rejected the upload with "the name 'docextract' is too similar to an existing project" (it collides with the pre-existing `doc-extract`; PyPI treats `-`/`_`/case as equivalent for uniqueness, which a plain exact-name availability check doesn't catch). Everything was renamed to `fastdocparse` — package, import name, CLI command, and the GitHub repo itself — rather than keeping a PyPI-name/import-name mismatch, since consistency was worth more than avoiding the rename churn.
+Decision: `docextract` was the original pick and was fully built under that name (import path, CLI command, GitHub repo), but PyPI rejected the upload with "the name 'docextract' is too similar to an existing project" (it collides with the pre-existing `doc-extract`; PyPI treats `-`/`_`/case as equivalent for uniqueness, which a plain exact-name availability check doesn't catch). Everything was renamed to `fastdocparse`: package, import name, CLI command, and the GitHub repo itself, rather than keeping a PyPI-name/import-name mismatch, since consistency was worth more than avoiding the rename churn.
 
 ---
 
@@ -229,15 +229,15 @@ Decision: `docextract` was the original pick and was fully built under that name
 
 - [ ] Does removing hand-tuning (Phase 1 → Phase 3) cost more accuracy than few-shot examples recover? (Answered by TC3.2.)
 - [ ] Is the CPU-only/no-GPU pipeline actually competitive on accuracy with Sparrow's vision-LLM approach on messy documents, or only on clean ones? (Answered by Phase 6 benchmark.)
-- [ ] Is a lightweight table-reconstruction step (Phase 4) sufficient, or does hard table extraction eventually require a vision component too — undercutting the "no GPU needed" claim for that subset of documents? (Flag honestly in docs either way.)
+- [ ] Is a lightweight table-reconstruction step (Phase 4) sufficient, or does hard table extraction eventually require a vision component too, undercutting the "no GPU needed" claim for that subset of documents? (Flag honestly in docs either way.)
 
 ---
 
 ## 7. Overall progress checklist
 
-- [ ] **Phase 1** — Generalized core (7 test cases)
-- [ ] **Phase 2** — Grounding & sanity checks (5 test cases)
-- [ ] **Phase 3** — Few-shot schema definition (3 test cases)
-- [ ] **Phase 4** — Layout-awareness for tables (3 test cases)
-- [ ] **Phase 5** — Multi-page & chunking (3 test cases)
-- [ ] **Phase 6** — Benchmark, package, publish (3 test cases)
+- [ ] **Phase 1**: Generalized core (7 test cases)
+- [ ] **Phase 2**: Grounding & sanity checks (5 test cases)
+- [ ] **Phase 3**: Few-shot schema definition (3 test cases)
+- [ ] **Phase 4**: Layout-awareness for tables (3 test cases)
+- [ ] **Phase 5**: Multi-page & chunking (3 test cases)
+- [ ] **Phase 6**: Benchmark, package, publish (3 test cases)


### PR DESCRIPTION
## Summary
Went through every markdown doc in the repo (README, CONTRIBUTING, CODE_OF_CONDUCT, the spec doc, and all 4 files in docs/) checking for stale facts, broken instructions, and drift against the current code — not a style pass, a factual-accuracy one.

Found and fixed 4 things:
- **README.md / CONTRIBUTING.md**: test count was stale at 74 — actual current count (verified via `pytest --collect-only`) is 75.
- **CONTRIBUTING.md**: the "CI must pass" line only listed `test (3.10)`/`test (3.12)` — the repo's actual `required_status_checks` also include `build` and `Analyze (python)`. A contributor could hit a legitimate merge block CONTRIBUTING.md didn't warn them about.
- **docs/getting-started.md**: the install section's `git clone <this repo>` / `cd document-extractor` predates the project's rename to `fastdocparse` — following it literally fails. Fixed to match README's already-correct clone command.
- **docs/architecture.md**: the module dependency graph had a `result --> schema` edge that doesn't exist — `result.py` only imports from `pydantic`/`typing`, no import of `schema.py`. Removed the stale edge; verified every other edge in the graph against real imports.

`schema-guide.md`, `output-format.md`, `document-extractor-spec.md`, and `CODE_OF_CONDUCT.md` were all checked and came back clean — no changes needed.

## Test plan
- Docs-only change, no source code touched
- Ran the full suite locally: 75 passed