### PR TITLE
feat(cli): add top-level version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ No extra LLM call for any of this: it's deterministic, string/rule-based validat
 
 | | Who it's for | How |
 |---|---|---|
-| **CLI** | No coding needed | `fastdocparse extract <file> <schema.json>` |
+| **CLI** | No coding needed | `fastdocparse extract <file> <schema.json>` / `fastdocparse --version` |
 | **Python API** | Building it into your own app | `DocumentParser(client).extract(document_bytes, schema)` |
 
 Defining *what* to extract also has two paths: hand-write a JSON/YAML schema file, or describe it in plain English and let the LLM draft the schema for you.

--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import typer
 from pydantic import ValidationError
 
+from . import __version__
 from .llm_client import LLMClient, LLMClientError
 from .parser import DocumentParser, EmptyDocumentError, UnknownIngestionKindError
 from .schema import Schema
@@ -46,6 +47,27 @@ app = typer.Typer(
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg"}
 SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS | {".pdf"}
+
+
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+
+    typer.echo(f"fastdocparse {__version__}")
+    raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the version and exit.",
+    ),
+) -> None:
+    return None
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
+from fastdocparse import __version__
 from fastdocparse.cli import app
 
 runner = CliRunner()
@@ -33,6 +34,13 @@ def test_extract_command_success():
     payload = json.loads(result.output)
     assert payload["invoice_number"]["value"] == "INV-1"
     assert "_meta" in payload
+
+
+def test_version_flag_prints_package_version():
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == f"fastdocparse {__version__}"
 
 
 def test_extract_command_rejects_unsupported_extension(tmp_path):


### PR DESCRIPTION
## What this does

Fixes #37.

Adds a top-level `--version` option to the Typer app so `fastdocparse --version` prints the installed package version and exits cleanly without requiring a subcommand.

## Checklist

- [x] Added or updated tests for anything behavioral this changes
- [x] Ran the full suite locally (`pytest -v`), not just the file touched
- [x] Updated `docs/` and/or `README.md` if a CLI flag, `Schema`/`Field` option, or output shape changed
- [x] Kept the PR scoped to one thing (see `CONTRIBUTING.md` if unsure)

## Validation

- `./.venv/bin/pytest -v`
- `./.venv/bin/fastdocparse --version`
- `git diff --check`
