### PR TITLE
test: skip ReDoS-guard test on non-SIGALRM platforms

### DIFF
--- a/tests/test_severe_edge_cases.py
+++ b/tests/test_severe_edge_cases.py
@@ -22,9 +22,10 @@ from fastdocparse.schema import Field, Schema
     not hasattr(signal, "SIGALRM"),
     reason=(
         "The ReDoS guard in grounding.py (_regex_matches_with_timeout) relies on "
-        "SIGALRM, which doesn't exist on Windows. There, the guard documents that it "
-        "runs the match with no timeout at all — a known, accepted gap, not something "
-        "this test can meaningfully assert against on this platform. See issue #28."
+        "SIGALRM. On any platform lacking it (Windows is the common case), the guard "
+        "documents that it runs the match with no timeout at all: a known, accepted "
+        "gap, not something this test can meaningfully assert against there. "
+        "See issue #28."
     ),
 )
 def test_catastrophic_backtracking_pattern_does_not_hang():

--- a/tests/test_severe_edge_cases.py
+++ b/tests/test_severe_edge_cases.py
@@ -4,6 +4,7 @@ Each test here reproduces a real bug found by hand — not a hypothetical — an
 fixed behavior down so it can't silently regress.
 """
 
+import signal
 import subprocess
 import sys
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,15 @@ from fastdocparse.pdf_utils import chunk_document_text, extract_layout_markdown_
 from fastdocparse.schema import Field, Schema
 
 
+@pytest.mark.skipif(
+    not hasattr(signal, "SIGALRM"),
+    reason=(
+        "The ReDoS guard in grounding.py (_regex_matches_with_timeout) relies on "
+        "SIGALRM, which doesn't exist on Windows. There, the guard documents that it "
+        "runs the match with no timeout at all — a known, accepted gap, not something "
+        "this test can meaningfully assert against on this platform. See issue #28."
+    ),
+)
 def test_catastrophic_backtracking_pattern_does_not_hang():
     """A pathological user/LLM-supplied regex must not be able to hang extraction.
     Run in a subprocess with a hard wall-clock timeout — a naive thread-based guard


### PR DESCRIPTION
## Summary
- Root cause of #28 doesn't need Windows to confirm: `_regex_matches_with_timeout` in `grounding.py` already documents that on platforms without `SIGALRM` (Windows), it runs the regex match with zero timeout protection. That's a known, accepted gap, not flaky timing.
- Test was failing red on Windows with no explanation. Now it skips cleanly there with a message pointing at the real reason.

## Not in scope here
- Whether to add a Windows CI job, or build a real Windows-side mitigation, is a separate, bigger design call — left for a follow-up discussion, not bundled into this fix.

## Test plan
- [x] `pytest tests/test_severe_edge_cases.py -v` — 12 passed locally (Mac has SIGALRM, so skip doesn't trigger here; it will on a Windows runner)