### PR TITLE
chore: release 0.3.0

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,12 @@ A schema is a JSON (or YAML) file listing the fields you want extracted. Two are
 
 Copy one and edit field names/descriptions for your document type, or write your own from scratch. See the [Schema Guide](schema-guide.md) for every option.
 
+Not sure what's bundled or where it lives? List them from the CLI:
+
+```bash
+fastdocparse list-schemas
+```
+
 **Don't want to write JSON at all?** Describe what you want in plain English:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastdocparse"
-version = "0.2.0"
+version = "0.3.0"
 description = "Extract structured data from semi-structured documents using any OpenAI-compatible LLM, with per-field grounding and confidence."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Version bump for 0.3.0. Since 0.2.0 (live on PyPI):
- Local-model support: FASTDOCPARSE_MODEL/FASTDOCPARSE_BASE_URL env vars, OPENAI_API_KEY actually read, fail-fast credentials check (#44)
- Friendly missing-schema error + new `list-schemas` command (#35)
- `--version` flag (#43)
- ReDoS-guard test now skips cleanly on non-SIGALRM platforms instead of failing red (#45)
- Docstrings, lint cleanup, doc proofread pass

Also documents `list-schemas` in getting-started.md (was missing).

## Test plan
- [x] `pytest` — 83 passed
- [x] `ruff check` — clean