### PR TITLE
feat(cli): add validate-schema command to check schema files without extraction

### DIFF
--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -228,5 +228,24 @@ def list_schemas():
     )
 
 
+@app.command(name="validate-schema")
+def validate_schema(
+    schema: Path = typer.Argument(..., exists=True, readable=True, help="Path to the .json or .yaml schema file to validate."),
+):
+    """Check that a schema file is well-formed without needing a document or LLM credentials."""
+    try:
+        doc_schema = Schema.from_file(schema)
+    except (ValidationError, ValueError, OSError) as e:
+        typer.echo(f"Could not load schema from {schema}: {e}", err=True)
+        raise typer.Exit(code=1)
+
+    fields_count = len(doc_schema.fields)
+    examples_count = len(doc_schema.examples) if doc_schema.examples else 0
+    if examples_count > 0:
+        typer.echo(f"Schema '{doc_schema.name}' is valid: {fields_count} field(s), {examples_count} example(s).")
+    else:
+        typer.echo(f"Schema '{doc_schema.name}' is valid: {fields_count} field(s).")
+
+
 if __name__ == "__main__":
     app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,6 +225,41 @@ def test_list_schemas_shows_bundled_schemas():
     assert "invoice" in result.output.lower()
 
 
+def test_validate_schema_valid_bundled():
+    """validate-schema should successfully validate a bundled schema and report field count."""
+    result = runner.invoke(app, ["validate-schema", str(INVOICE_SCHEMA_PATH)])
+
+    assert result.exit_code == 0
+    assert "Schema 'Invoice' is valid" in result.output
+    assert "field(s)" in result.output
+
+
+def test_validate_schema_invalid_reserved_field(tmp_path):
+    """validate-schema should reject schemas using reserved field names like _meta."""
+    bad_schema = tmp_path / "bad_schema.json"
+    bad_schema.write_text(json.dumps({
+        "name": "Bad",
+        "fields": [{"name": "_meta", "description": "reserved"}],
+    }))
+
+    result = runner.invoke(app, ["validate-schema", str(bad_schema)])
+
+    assert result.exit_code == 1
+    assert "Could not load schema" in result.output
+    assert "_meta" in result.output
+
+
+def test_validate_schema_invalid_json(tmp_path):
+    """validate-schema should report clear error for malformed json."""
+    broken_file = tmp_path / "broken.json"
+    broken_file.write_text("{not-valid-json")
+
+    result = runner.invoke(app, ["validate-schema", str(broken_file)])
+
+    assert result.exit_code == 1
+    assert "Could not load schema" in result.output
+
+
 def test_extract_command_rejects_unreadable_schema_cleanly(tmp_path):
     """A schema that exists but can't be read (permission denied) must fail with a clean
     Typer-level error, not skip straight past the friendly-missing-schema path and crash


### PR DESCRIPTION
## Summary

Adds a new fastdocparse validate-schema <path> command that validates schema files without requiring document inputs or LLM credentials:

- Reuses Schema.from_file() for validation.
- Prints confirmation with field and example counts on success (e.g. Schema 'Invoice' is valid: 7 field(s).).
- Emits clean error output and exits with code 1 on schema validation or file reading failure.
- Adds comprehensive unit tests in tests/test_cli.py covering valid schemas, invalid reserved fields, and malformed JSON.

Fixes #56

## Validation
- Ran pytest tests/test_cli.py -k validate_schema (3/3 passing).