### PR TITLE
feat(cli): describe each bundled schema in list-schemas (closes #55)

### DIFF
--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -220,9 +220,36 @@ def list_schemas():
         raise typer.Exit(code=1)
 
     typer.echo("Bundled example schemas (copy one as your starting point):\n")
+
+    # Load each schema rather than listing its path. A bare path tells the reader
+    # nothing about which one fits their document, so the only way to choose was
+    # to open both files -- which is the thing this command exists to save.
+    described: list[tuple[str, str]] = []
     for path in schema_files:
-        typer.echo(f"  {path}")
+        try:
+            schema = Schema.from_file(path)
+        except Exception:
+            # A bundled schema that will not parse is a packaging fault, not a
+            # reason to show nothing: the filename is still copyable, which is
+            # what this command is for.
+            described.append((path.name, ""))
+            continue
+        preview = ", ".join(f.name for f in schema.fields[:3])
+        if len(schema.fields) > 3:
+            preview += ", ..."
+        plural = "s" if len(schema.fields) != 1 else ""
+        described.append(
+            (path.name, f"{schema.name}: {preview} ({len(schema.fields)} field{plural})")
+        )
+
+    width = max(len(name) for name, _ in described)
+    for name, summary in described:
+        typer.echo(f"  {name.ljust(width)}  {summary}".rstrip())
+
+    # The directory is printed once instead of on every row: it is the same for
+    # all of them, and repeating it is what pushed the useful part off the line.
     typer.echo(
+        f"\nThey are in:\n  {schemas_dir}\n"
         "\nTo use one directly:\n"
         "  fastdocparse extract document.pdf " + str(schema_files[0])
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,6 +225,53 @@ def test_list_schemas_shows_bundled_schemas():
     assert "invoice" in result.output.lower()
 
 
+def test_list_schemas_describes_each_one(_capture=None):
+    """A bare path does not say which schema fits your document (#55)."""
+    result = runner.invoke(app, ["list-schemas"])
+
+    assert result.exit_code == 0
+    # The schema's own name, some of its field names, and how many there are.
+    assert "Invoice:" in result.output
+    assert "invoice_number" in result.output
+    assert "fields)" in result.output
+
+
+def test_list_schemas_names_files_not_absolute_paths_per_row():
+    """The directory is the same for every row; repeating it hid the useful part."""
+    result = runner.invoke(app, ["list-schemas"])
+    rows = [
+        line for line in result.output.splitlines()
+        if line.startswith("  ") and ".json" in line and "extract document.pdf" not in line
+    ]
+
+    assert rows, result.output
+    for row in rows:
+        assert row.strip().startswith(("invoice.json", "shipment_manifest.json")), row
+
+
+def test_list_schemas_still_prints_a_copyable_location():
+    """Dropping the path per row must not remove the reader's way to find them."""
+    result = runner.invoke(app, ["list-schemas"])
+
+    assert "They are in:" in result.output
+    assert "schemas" in result.output
+
+
+def test_list_schemas_field_count_matches_the_schema():
+    """The count is read from the file, not written down beside it."""
+    from pathlib import Path
+
+    from fastdocparse import cli
+    from fastdocparse.schema import Schema
+
+    bundled = Path(cli.__file__).parent / "schemas" / "invoice.json"
+    expected = len(Schema.from_file(bundled).fields)
+
+    result = runner.invoke(app, ["list-schemas"])
+
+    assert f"({expected} fields)" in result.output
+
+
 def test_extract_command_rejects_unreadable_schema_cleanly(tmp_path):
     """A schema that exists but can't be read (permission denied) must fail with a clean
     Typer-level error, not skip straight past the friendly-missing-schema path and crash


### PR DESCRIPTION
Closes #55.

## Before / after

```console
$ fastdocparse list-schemas
Bundled example schemas (copy one as your starting point):

  invoice.json            Invoice: invoice_number, invoice_date, exporter_name, ... (9 fields)
  shipment_manifest.json  ShipmentManifest: bill_of_lading, container_number, hs_code, ... (7 fields)

They are in:
  .../src/fastdocparse/schemas

To use one directly:
  fastdocparse extract document.pdf .../schemas/invoice.json
```

Loaded with `Schema.from_file`, as the issue suggests.

## Two small decisions

**The directory moved rather than went.** Printing the absolute path on every row is what pushed the useful part off the line — but deleting it outright would remove the reader's way to actually find the files to copy. So each row is a filename, and the directory is printed once underneath. A test pins both halves: rows start with a filename, and `They are in:` is still there.

**Everything shown is read from the file.** The name, the field preview and the count all come from the parsed schema, so a schema gaining a field cannot make this output stale. `test_list_schemas_field_count_matches_the_schema` asserts the printed count against `Schema.from_file` rather than hard-coding 9 — otherwise the test would need editing every time a schema changes, and would eventually be "fixed" by updating the number instead of the code.

**A schema that will not parse falls back to its filename** rather than failing the command. That's a packaging fault, and the filename is still copyable, which is the whole point of the command.

## Tests

Four new in `tests/test_cli.py`, beside `test_list_schemas_shows_bundled_schemas`:

- each schema is described (name, a field name, a count)
- rows name files, not absolute paths
- the location is still printed somewhere
- the count matches what `Schema.from_file` reports

All four fail with `cli.py` stashed; the existing `test_list_schemas_shows_bundled_schemas` correctly stays green.

## Verification

- `pytest -q` — **85 passed, 1 skipped, 1 failed**

That one failure is `test_extract_command_rejects_unreadable_schema_cleanly`, and it fails identically on pristine `main` here: it uses `chmod(0o000)` to make a file unreadable, which does not remove read access on Windows, so the test's premise never holds. Unrelated to this PR — happy to open a separate issue for it if you'd like it skipped on Windows.