### PR TITLE
test(cli): make the unreadable-schema test hold its premise on Windows (closes #63)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the CLI entrypoint."""
 
+import os
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -225,17 +226,47 @@ def test_list_schemas_shows_bundled_schemas():
     assert "invoice" in result.output.lower()
 
 
-def test_extract_command_rejects_unreadable_schema_cleanly(tmp_path):
+def test_extract_command_rejects_unreadable_schema_cleanly(tmp_path, monkeypatch):
     """A schema that exists but can't be read (permission denied) must fail with a clean
     Typer-level error, not skip straight past the friendly-missing-schema path and crash
-    later with a raw OSError when the code tries to actually open it."""
+    later with a raw OSError when the code tries to actually open it.
+
+    `os.access` is patched rather than the file's mode being changed. `chmod(0o000)`
+    does not remove the owner's read access on Windows -- the permission model is
+    ACL-based and `chmod` only maps to the read-only attribute -- so `os.access(...,
+    R_OK)` still answered True, the guard under test never fired, and the command
+    went on to fail about missing LLM credentials instead. The test was not detecting
+    a Windows bug; it could not establish its own premise there. Patching the call
+    that Typer's `readable=True` actually makes exercises the same code path
+    identically on every platform.
+    """
     unreadable_schema = tmp_path / "no_access.json"
     unreadable_schema.write_text('{"name": "T", "fields": []}')
-    unreadable_schema.chmod(0o000)
-    try:
-        result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE), str(unreadable_schema)])
-    finally:
-        unreadable_schema.chmod(0o644)
+
+    real_access = os.access
+
+    def deny_reading_the_schema(path, mode, *args, **kwargs):
+        if Path(path) == unreadable_schema and mode & os.R_OK:
+            return False
+        return real_access(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os, "access", deny_reading_the_schema)
+
+    result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE), str(unreadable_schema)])
 
     assert result.exit_code != 0
     assert "readable" in result.output.lower()
+
+
+def test_extract_command_still_accepts_a_readable_schema(tmp_path):
+    """The control: the guard must fire on unreadability, not on every schema.
+
+    Without this, the test above would pass just as happily against a check that
+    refused every path handed to it.
+    """
+    schema_file = tmp_path / "fine.json"
+    schema_file.write_text('{"name": "T", "fields": [{"name": "x", "description": "x"}]}')
+
+    result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE), str(schema_file)])
+
+    assert "readable" not in result.output.lower()


### PR DESCRIPTION
Closes #63. Found while reproducing #28.

## The test was not failing — it was unable to run

On Windows, `test_extract_command_rejects_unreadable_schema_cleanly` failed like this:

```
E   assert 'readable' in "error: no llm credentials configured. …"
```

`chmod(0o000)` does not remove the **owner's** read access on Windows. The permission model is ACL-based and `chmod` only maps to the read-only attribute, so `os.access(path, R_OK)` — which is what Typer's `readable=True` calls — still answered `True`.

So the file stayed readable, the guard under test never fired, `extract` proceeded, and it failed later about missing LLM credentials. The assertion then compared against that unrelated error.

That distinction is the whole point: it was **not** detecting a Windows defect in the guard. It could not establish the condition it wanted to test, and reported a failure about something else.

## Patched, not skipped

Skipping on Windows would have made the suite green while leaving the guard untested on the platform. Patching `os.access` exercises the same code path identically everywhere, so the guard is genuinely covered on Windows now.

The patch is scoped to the one path — every other `os.access` call falls through to the real one — so it can't mask an unrelated permission check.

## The control

`test_extract_command_still_accepts_a_readable_schema` asserts a readable schema is **not** refused. Without it, the test above would pass just as happily against a check that refused every path handed to it, which is a real risk when you replace a filesystem condition with a stub.

## Verified the test is load-bearing

Removing the `monkeypatch.setattr` line makes it fail — which is precisely the old Windows behaviour. So the patch is what establishes the premise, not decoration.

## Result

```
83 passed, 1 skipped, 0 failed
```

The suite is green on Windows for the first time. The 1 skip is `test_catastrophic_backtracking_pattern_does_not_hang`, which is #28's deliberate SIGALRM skip and already on `main`.

## Note on CI

`.github/workflows/ci.yml` runs `ubuntu-latest` only, which is why neither this nor #28 surfaced there. Not proposing a matrix change in this PR — #28 already raises that question and it deserves its own decision — but with this landed, a Windows job would pass rather than immediately reporting two failures.