### PR TITLE
test: add control test for unreadable-schema os.access patch

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -358,4 +358,7 @@ def test_extract_command_still_accepts_a_readable_schema(tmp_path):
     with patch("fastdocparse.llm_client.OpenAI", return_value=_mock_openai_returning(fake_result)):
         result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE), str(schema_file), "--api-key", "test-key"])
 
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["x"]["value"] == "value"
     assert "readable" not in result.output.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -344,3 +344,18 @@ def test_extract_command_rejects_unreadable_schema_cleanly(tmp_path, monkeypatch
 
     assert result.exit_code != 0
     assert "readable" in result.output.lower()
+
+
+def test_extract_command_still_accepts_a_readable_schema(tmp_path):
+    """The control for the test above: the guard must fire on unreadability
+    specifically, not on every schema path handed to it. Without this, the
+    os.access patch above would pass just as happily against a check that
+    refused everything. Credit: PR #64 (dchaudhari7177)."""
+    schema_file = tmp_path / "fine.json"
+    schema_file.write_text('{"name": "T", "fields": [{"name": "x", "description": "x"}]}')
+
+    fake_result = json.dumps({"x": "value"})
+    with patch("fastdocparse.llm_client.OpenAI", return_value=_mock_openai_returning(fake_result)):
+        result = runner.invoke(app, ["extract", str(SAMPLE_IMAGE), str(schema_file), "--api-key", "test-key"])
+
+    assert "readable" not in result.output.lower()


### PR DESCRIPTION
## Why this exists

PR #64 (Dipak Chaudhari / dchaudhari7177, closing #63) found and fixed the same Windows chmod issue independently while adding Windows CI, and the core fix (patching os.access instead of chmod) already landed on main via PR #67.

#64's core fix is therefore redundant now, but it included a genuinely valuable control test that #67 didn't carry over: `test_extract_command_still_accepts_a_readable_schema`, asserting the guard fires on unreadability specifically, not on every schema path. Without it, the os.access patch could pass against a check that rejected everything.

This PR adds just that control test, credited to Dipak Chaudhari via Co-Authored-By.

## Test plan
- [x] `pytest` — 91 passed
- [x] `ruff check` — clean