### PR TITLE
fix: include YAML schemas in list-schemas

### DIFF
--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -214,6 +214,14 @@ def schema_from_text(
     typer.echo("Review it, then run: fastdocparse extract <your_document> " + str(output))
 
 
+def _bundled_schema_files(schemas_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for pattern in ("*.json", "*.yaml", "*.yml")
+        for path in schemas_dir.glob(pattern)
+    )
+
+
 @app.command(name="list-schemas")
 def list_schemas():
     """List the bundled example schemas you can copy as a starting point.
@@ -222,7 +230,7 @@ def list_schemas():
     This is the fastest way to get started without an LLM-generated schema.
     """
     schemas_dir = Path(__file__).parent / "schemas"
-    schema_files = sorted(schemas_dir.glob("*.json"))
+    schema_files = _bundled_schema_files(schemas_dir)
     if not schema_files:
         typer.echo("No bundled schemas found.", err=True)
         raise typer.Exit(code=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
 from fastdocparse import __version__
-from fastdocparse.cli import app
+from fastdocparse.cli import _bundled_schema_files, app
 from fastdocparse.config import ExtractionConfig
 
 runner = CliRunner()
@@ -114,6 +114,17 @@ def test_version_flag_prints_package_version():
     assert result.exit_code == 0
     assert result.output.strip() == f"fastdocparse {__version__}"
 
+
+def test_bundled_schema_files_include_yaml_extensions(tmp_path):
+    for filename in ("invoice.json", "receipt.yaml", "shipment.yml"):
+        (tmp_path / filename).touch()
+    (tmp_path / "notes.txt").touch()
+
+    assert [path.name for path in _bundled_schema_files(tmp_path)] == [
+        "invoice.json",
+        "receipt.yaml",
+        "shipment.yml",
+    ]
 
 def test_extract_command_rejects_unsupported_extension(tmp_path):
     bad_file = tmp_path / "resume.docx"


### PR DESCRIPTION
Closes #71

## Summary
- Discover bundled `.json`, `.yaml`, and `.yml` schemas from `list-schemas`.
- Keep deterministic filename ordering.
- Add a focused test proving supported schema extensions are listed while unrelated files are ignored.

## Verification
- `python -m pytest -q tests/test_cli.py` — 30 passed.