### PR TITLE
fix(cli): pluralize validate-schema counts like list-schemas does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Dates are the PyPI upload dates, which are what a user upgrading actually sees.
 
 ### Fixed
 
+- `fastdocparse validate-schema` now pluralizes its summary properly ("1 field",
+  "3 fields, 1 example") instead of printing the literal "field(s)"/"example(s)",
+  matching what `list-schemas` already did ([#82]).
 - `test_extract_command_rejects_unreadable_schema_cleanly` could not establish its
   premise on Windows: `chmod(0o000)` does not remove the owner's read access there,
   so the guard under test never fired and the assertion compared against an
@@ -101,6 +104,7 @@ Dates are the PyPI upload dates, which are what a user upgrading actually sees.
 [#51]: https://github.com/pranjalparmar/fastdocparse/pull/51
 [#52]: https://github.com/pranjalparmar/fastdocparse/pull/52
 [#53]: https://github.com/pranjalparmar/fastdocparse/pull/53
+[#82]: https://github.com/pranjalparmar/fastdocparse/issues/82
 [#63]: https://github.com/pranjalparmar/fastdocparse/issues/63
 [Unreleased]: https://github.com/pranjalparmar/fastdocparse/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/pranjalparmar/fastdocparse/releases/tag/v0.3.0

--- a/src/fastdocparse/cli.py
+++ b/src/fastdocparse/cli.py
@@ -285,10 +285,15 @@ def validate_schema(
 
     fields_count = len(doc_schema.fields)
     examples_count = len(doc_schema.examples) if doc_schema.examples else 0
+    fields_plural = "s" if fields_count != 1 else ""
+    examples_plural = "s" if examples_count != 1 else ""
     if examples_count > 0:
-        typer.echo(f"Schema '{doc_schema.name}' is valid: {fields_count} field(s), {examples_count} example(s).")
+        typer.echo(
+            f"Schema '{doc_schema.name}' is valid: {fields_count} field{fields_plural}, "
+            f"{examples_count} example{examples_plural}."
+        )
     else:
-        typer.echo(f"Schema '{doc_schema.name}' is valid: {fields_count} field(s).")
+        typer.echo(f"Schema '{doc_schema.name}' is valid: {fields_count} field{fields_plural}.")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -317,7 +317,27 @@ def test_validate_schema_valid_bundled():
 
     assert result.exit_code == 0
     assert "Schema 'Invoice' is valid" in result.output
-    assert "field(s)" in result.output
+    from fastdocparse.schema import Schema
+
+    fields = len(Schema.from_file(INVOICE_SCHEMA_PATH).fields)
+    assert f"{fields} fields" in result.output
+    assert "field(s)" not in result.output
+
+
+def test_validate_schema_singular_counts(tmp_path):
+    schema_file = tmp_path / "one.json"
+    schema_file.write_text(
+        json.dumps(
+            {
+                "name": "One",
+                "fields": [{"name": "x", "description": "x"}],
+                "examples": [["x is 1", {"x": "1"}]],
+            }
+        )
+    )
+    result = runner.invoke(app, ["validate-schema", str(schema_file)])
+    assert result.exit_code == 0
+    assert "1 field, 1 example." in result.output
 
 
 def test_validate_schema_invalid_reserved_field(tmp_path):


### PR DESCRIPTION
## What this does

Fixes #82.

`validate-schema` printed the literal `field(s)` / `example(s)` regardless of count. `list_schemas()` in the same file already does real singular/plural handling, so this applies the same approach to `validate_schema()` for both counts:

```
Schema 'Invoice' is valid: 9 fields, 1 example.
Schema 'One' is valid: 1 field, 1 example.
```

Tests: the existing `test_validate_schema_valid_bundled` assertion now checks for the real plural (and that `field(s)` is gone), and a new `test_validate_schema_singular_counts` covers the `1 field, 1 example` case. Changelog entry added under Unreleased / Fixed.

## Checklist

- [x] Added or updated tests for anything behavioral this changes
- [x] Ran the full suite locally (`pytest -v`), not just the file touched — 97 passed on Python 3.12
- [x] Updated `docs/` and/or `README.md` if a CLI flag, `Schema`/`Field` option, or output shape changed — no docs quote this message, so only CHANGELOG.md changed
- [x] Kept the PR scoped to one thing (see `CONTRIBUTING.md` if unsure)
